### PR TITLE
Show recently visited tasks in the menu bar

### DIFF
--- a/front/src/layouts/MainLayout.vue
+++ b/front/src/layouts/MainLayout.vue
@@ -28,6 +28,19 @@
               :label="currentTask.title"
               v-if="currentTask"
             />
+            <div
+            v-for="(task) in recentTasks" :key="task.id">              
+            <q-btn
+                :to="{
+                  name: 'task',
+                  params: { ctfSlug: currentCtf.slug, taskSlug: task.slug }
+                }"
+                stretch
+                flat
+                :label="task.title"
+                v-if="task != null && task != currentTask"
+              />
+            </div>
           </div>
         </q-toolbar-title>
         <q-btn-dropdown stretch flat :label="currentUser.username" v-if="currentUser">
@@ -117,7 +130,7 @@ export default {
     }
   },
   computed: {
-    ...mapGetters(["currentCtf", "ctfs", "currentUser", "currentTask", "isAdmin", "loading"]),
+    ...mapGetters(["currentCtf", "ctfs", "currentUser", "currentTask", "recentTasks", "isAdmin", "loading"]),
     menu() {
       if (!this.currentCtf || !this.currentCtf.tasks) return null;
       const categories = {};

--- a/front/src/store/index.js
+++ b/front/src/store/index.js
@@ -58,6 +58,7 @@ export default async function (/* { ssrContext } */) {
       currentUser: currentUser,
       currentCtf: null,
       currentTask: null,
+      recentTasks: [],
       loading: false
     },
     getters: {
@@ -67,6 +68,7 @@ export default async function (/* { ssrContext } */) {
       currentUser: state => state.currentUser,
       currentCtf: state => state.currentCtf,
       currentTask: state => state.currentTask,
+      recentTasks: state => state.recentTasks,
       isAdmin: (state, getters) => getters.isUserGranted(Rights.ADMIN_ALL),
       isCtfAdmin: (state, getters) => getters.isUserGranted(Rights.EDIT_CTF),
       isUserGranted: state => right => {
@@ -111,9 +113,16 @@ export default async function (/* { ssrContext } */) {
       clearCtf(state) {
         state.currentCtf = null;
         state.currentTask = null;
+        state.recentTasks = [];
       },
       setCurrentTask(state, task) {
         state.currentTask = task;
+      },
+      setRecentTask(state, task) {
+        let filtered = state.recentTasks.filter((t) => t.id != task.id)
+        filtered.unshift(task);
+        filtered.splice(3);
+        state.recentTasks = filtered;
       },
       deleteTask(state, taskSlug) {
         const idx = state.currentCtf.tasks.findIndex(t => t.slug == taskSlug);
@@ -130,6 +139,7 @@ export default async function (/* { ssrContext } */) {
           if (state.currentCtf.slug == ctfSlug) {
             state.currentCtf = null;
             state.currentTask = null;
+            state.recentTasks = [];
           }
         }
         state.ctfs.splice(idx, 1);
@@ -214,6 +224,7 @@ export default async function (/* { ssrContext } */) {
       },
       async setCurrentTask({ commit }, task) {
         commit("setCurrentTask", task);
+        commit("setRecentTask", task);
       },
       async importCtf({ commit }, ctfID) {
         return handleApiCall(commit, async () => {


### PR DESCRIPTION
Next to the current task, we show the 3 recent visited tasks.
The recent tasks are sorted by visit time. The most recent is on the left, the oldest on the right. The oldest task will be removed when more than 3 recent tasks will be displayed.
This will make navigating between tasks easier.