### PR TITLE
Increase credentials unblur time

### DIFF
--- a/front/src/pages/CTF/CTF.vue
+++ b/front/src/pages/CTF/CTF.vue
@@ -121,7 +121,7 @@ export default {
 }
 .blur:hover {
   filter: blur(0px);
-  transition-delay:0.2s;
+  transition-delay: 0.2s;
 }
 
 .head {

--- a/front/src/pages/CTF/CTF.vue
+++ b/front/src/pages/CTF/CTF.vue
@@ -121,6 +121,7 @@ export default {
 }
 .blur:hover {
   filter: blur(0px);
+  transition-delay:0.2s;
 }
 
 .head {


### PR DESCRIPTION
When your mouse crosses the credentials, they will instantly unblur.
This is not very useful when your screen is being recorded for example.
Now we add a small delay so you can only unblur the credentials when you explicitly hold your mouse on the credentials.