### PR TITLE
Change CodiMD 1.6 to HedgeDoc 1.7.2

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -34,7 +34,7 @@ services:
     ports:
       - 80:80
   codimd:
-    image: linuxserver/hedgedoc
+    image: quay.io/hedgedoc/hedgedoc:1.7.2-alpine
     environment:
       - CMD_DB_URL=postgres://ctfnote:ctfnote@db:5432/ctfnote
       - CMD_URL_PATH=pad

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -34,7 +34,7 @@ services:
     ports:
       - 80:80
   codimd:
-    image: quay.io/codimd/server:1.6.0
+    image: linuxserver/hedgedoc
     environment:
       - CMD_DB_URL=postgres://ctfnote:ctfnote@db:5432/ctfnote
       - CMD_URL_PATH=pad

--- a/front/nginx.conf
+++ b/front/nginx.conf
@@ -19,7 +19,7 @@ server {
         proxy_set_header Host $http_host;
         proxy_set_header X-Real-IP $remote_addr;
         proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
-	    proxy_set_header X-Forwarded-Proto $scheme;
+        proxy_set_header X-Forwarded-Proto $scheme;
         add_header Pragma "no-cache";
     }
 
@@ -29,7 +29,7 @@ server {
         proxy_set_header Host $http_host;
         proxy_set_header X-Real-IP $remote_addr;
         proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
-	    proxy_set_header X-Forwarded-Proto $scheme;
+        proxy_set_header X-Forwarded-Proto $scheme;
         add_header Pragma "no-cache";
     }
 }

--- a/front/nginx.conf
+++ b/front/nginx.conf
@@ -19,6 +19,7 @@ server {
         proxy_set_header Host $http_host;
         proxy_set_header X-Real-IP $remote_addr;
         proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
+	    proxy_set_header X-Forwarded-Proto $scheme;
         add_header Pragma "no-cache";
     }
 
@@ -28,6 +29,7 @@ server {
         proxy_set_header Host $http_host;
         proxy_set_header X-Real-IP $remote_addr;
         proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
+	    proxy_set_header X-Forwarded-Proto $scheme;
         add_header Pragma "no-cache";
     }
 }


### PR DESCRIPTION
CodiMD changed its name to HedgeDoc with the new update.
The nginx config was updated because of the update notes of 1.7.0:
https://github.com/hedgedoc/hedgedoc/releases/tag/1.7.0

I just searched for [HedgeDoc on hub.docker.com](https://hub.docker.com/search?q=hedgedoc&type=image) and picked the most popular one.
I have tested it myself and it seems to work just fine. But maybe you also want to test this before merging, so we can both confirm it will not cause any issues.