### PR TITLE
pad: set imgur as default upload service

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -38,6 +38,7 @@ services:
     environment:
       - CMD_DB_URL=postgres://ctfnote:ctfnote@db:5432/ctfnote
       - CMD_URL_PATH=pad
+      - CMD_IMAGE_UPLOAD_TYPE=imgur
     depends_on:
       - db
     restart: always


### PR DESCRIPTION
Previous versions of codimd used imgur to store uploaded images. This behaviour
changed to local filesystem when we upgraded to Hedgedoc.

This commit reverts the uploading feature to the previous behaviour.

This fixes #18 