### PR TITLE
Improve docker-compose.yml

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -3,6 +3,9 @@ services:
   api:
     build:
       context: "./api"
+    deploy:
+      restart_policy:
+        condition: on-failure
     networks:
       - ctfnote
     environment:
@@ -28,6 +31,9 @@ services:
       args:
         API_HOST: api
         PAD_HOST: codimd
+    deploy:
+      restart_policy:
+        condition: on-failure
     depends_on:
       - api
       - codimd

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -20,7 +20,7 @@ services:
       POSTGRES_PASSWORD: ctfnote
       POSTGRES_USER: ctfnote
     volumes:
-      - ctfnote:/data
+      - ctfnote:/var/lib/postgresql/data
     networks:
       - ctfnote
   front:

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -3,9 +3,6 @@ services:
   api:
     build:
       context: "./api"
-    deploy:
-      restart_policy:
-        condition: on-failure
     networks:
       - ctfnote
     environment:
@@ -31,9 +28,6 @@ services:
       args:
         API_HOST: api
         PAD_HOST: codimd
-    deploy:
-      restart_policy:
-        condition: on-failure
     depends_on:
       - api
       - codimd


### PR DESCRIPTION
The current `docker-compose.yml` has two issues:
- The containers `api` and `front` aren't restarted automatically on failure (in contrast to `db` and `codimd`).
- The path for the ctfnote volume is wrong. This causes the database to be lost when the `db`-container is recreated.

The fix for the second issue has a small problem. Since volumes aren't recreated when running `docker-compose up`, the old and wrong path will be used until the old volume is recreated. The easiest way to achieve this is executing `docker volume rm ctfnote`. An alternative approach would be to rename the volume to something like `ctfnote2`. I have opted for the first choice but am open to discussing about the correct approuch.