### PR TITLE
Add feature for storing flag in database

### DIFF
--- a/api/src/config/globals.ts
+++ b/api/src/config/globals.ts
@@ -32,12 +32,13 @@ export default class Globals {
   };
 
   static async init() {
-    Globals.mdCreateUrl = await PersistentConfiguration.setIfNotSet("md-create-url", Globals.mdCreateUrl);
-    Globals.mdShowUrl = await PersistentConfiguration.setIfNotSet("md-show-url", Globals.mdShowUrl);
+    Globals.mdCreateUrl = await PersistentConfiguration.setIfNotSet("md-create-url", Globals.mdCreateUrl, true);
+    Globals.mdShowUrl = await PersistentConfiguration.setIfNotSet("md-show-url", Globals.mdShowUrl, true);
     Globals.allowRegistration = await PersistentConfiguration.setIfNotSet(
       "allow-registration",
-      Globals.allowRegistration
+      Globals.allowRegistration,
+      true
     );
-    Globals.storeFlag = await PersistentConfiguration.setIfNotSet("store-flag", Globals.storeFlag);
+    Globals.storeFlag = await PersistentConfiguration.setIfNotSet("store-flag", Globals.storeFlag, false);
   }
 }

--- a/api/src/config/globals.ts
+++ b/api/src/config/globals.ts
@@ -23,6 +23,8 @@ export default class Globals {
   static mdCreateUrl = process.env.MD_CREATE_URL || "http://front/pad/new";
   static mdShowUrl = process.env.MD_SHOW_URL || "/pad";
 
+  static storeFlag = process.env.CTFNOTE_STORE_FLAG || true;
+
   static maxCtfPerPage = 20;
 
   static updatableFields = {
@@ -36,5 +38,6 @@ export default class Globals {
       "allow-registration",
       Globals.allowRegistration
     );
+    Globals.storeFlag = await PersistentConfiguration.setIfNotSet("store-flag", Globals.storeFlag);
   }
 }

--- a/api/src/config/persitent.ts
+++ b/api/src/config/persitent.ts
@@ -9,14 +9,20 @@ export default class PersistentConfiguration {
     return value;
   }
 
-  static async list(): Promise<any> {
+  static async list(priv = true): Promise<any> {
     const configRepo = getConnection().getRepository(Config);
     const items = await configRepo.find({ order: { id: "ASC" } });
 
     const obj = {};
 
     for (const [_, config] of Object.entries(items)) {
-      obj[config.key] = config.value;
+      if (priv) {
+        obj[config.key] = config.value;
+      } else {
+        if (!config.private) {
+          obj[config.key] = config.value;
+        }
+      }
     }
 
     return obj;

--- a/api/src/config/persitent.ts
+++ b/api/src/config/persitent.ts
@@ -28,16 +28,21 @@ export default class PersistentConfiguration {
     return obj;
   }
 
-  static async set(key: string, value: any): Promise<any | null> {
+  static async set(key: string, value: any, priv: boolean): Promise<any | null> {
     const connection = getConnection();
 
     if (await PersistentConfiguration.configExists(key)) {
-      return await connection.createQueryBuilder().update(Config).set({ value }).where("key = :key", { key }).execute();
+      return await connection
+        .createQueryBuilder()
+        .update(Config)
+        .set({ value, private: priv })
+        .where("key = :key", { key })
+        .execute();
     }
 
     const configRepo = connection.getRepository(Config);
 
-    const config = configRepo.create({ key, value });
+    const config = configRepo.create({ key, value, private: priv });
 
     return await configRepo.save(config);
   }
@@ -47,9 +52,9 @@ export default class PersistentConfiguration {
     return !!found;
   }
 
-  static async setIfNotSet(key: string, value: any) {
+  static async setIfNotSet(key: string, value: any, priv: boolean) {
     if (!(await PersistentConfiguration.configExists(key))) {
-      await PersistentConfiguration.set(key, value);
+      await PersistentConfiguration.set(key, value, priv);
       return value;
     }
 

--- a/api/src/config/routes.ts
+++ b/api/src/config/routes.ts
@@ -18,6 +18,7 @@ import UpdateCTFAction from "../controllers/ctf.controller/update.action";
 import CreateCtfAction from "../controllers/ctf.controller/create.action";
 
 import GetConfigAction from "../controllers/config.controller/get.action";
+import GetSettingsAction from "../controllers/settings.controller/get.action";
 import UpdateConfigAction from "../controllers/config.controller/update.action";
 import LogoutAction from "../controllers/auth.controller/logout.action";
 import RemoveCTFAction from "../controllers/ctf.controller/remove.action";
@@ -49,6 +50,8 @@ export class Routes {
 
     app.get("/admin/config", [...GetConfigAction.middlewares], GetConfigAction.action);
     app.put("/admin/config", [...UpdateConfigAction.middlewares, UpdateConfigAction.action]);
+
+    app.get("/settings", [...GetConfigAction.middlewares], GetSettingsAction.action);
 
     // 404 Handling
     app.use((_: any, res: Response) => {

--- a/api/src/controllers/config.controller/update.action.ts
+++ b/api/src/controllers/config.controller/update.action.ts
@@ -13,17 +13,20 @@ const UpdateConfigAction: IRoute = {
     body("md-create-url").optional(),
     body("md-show-url").optional(),
     body("allow-registration").optional().isBoolean(),
+    body("store-flag").optional().isBoolean(),
   ],
   async action(req: Request, res: Response, next) {
     const {
       "md-create-url": mdCreateUrl,
       "md-show-url": mdShowUrl,
       "allow-registration": allowRegistration,
+      "store-flag": storeFlag,
     } = req.body;
 
     if (mdCreateUrl != null) await PersistentConfiguration.set("md-create-url", mdCreateUrl);
     if (mdShowUrl != null) await PersistentConfiguration.set("md-show-url", mdShowUrl);
     if (allowRegistration != null) await PersistentConfiguration.set("allow-registration", allowRegistration);
+    if (storeFlag != null) await PersistentConfiguration.set("store-flag", storeFlag);
 
     return res.status(200).json(await PersistentConfiguration.list());
   },

--- a/api/src/controllers/settings.controller/get.action.ts
+++ b/api/src/controllers/settings.controller/get.action.ts
@@ -1,0 +1,14 @@
+import { Request, Response } from "express";
+import PersistentConfiguration from "../../config/persitent";
+import SessionManager from "../../utils/session";
+import IRoute from "../route";
+
+const GetSettingsAction: IRoute = {
+  middlewares: [SessionManager.authMiddleware],
+  async action(req: Request, res: Response, next) {
+    const config = await PersistentConfiguration.list(false);
+    return res.json(config);
+  },
+};
+
+export default GetSettingsAction;

--- a/api/src/controllers/task.controller/update.action.ts
+++ b/api/src/controllers/task.controller/update.action.ts
@@ -40,7 +40,7 @@ const UpdateTaskAction: IRoute = {
     let task = ctf.tasks.find((t) => t.slug === taskSlug);
     if (!task) return res.status(404).json({ errors: [{ msg: "Invalid Task slug" }] });
 
-    for (const field of ["solved", "title", "category", "description"]) {
+    for (const field of ["solved", "title", "category", "description", "flag"]) {
       if (field in req.body) {
         task[field] = req.body[field];
       }

--- a/api/src/entity/Config.ts
+++ b/api/src/entity/Config.ts
@@ -10,4 +10,7 @@ export default class Config {
 
   @Column("json")
   value: any;
+
+  @Column("boolean")
+  private: boolean;
 }

--- a/api/src/entity/Task.ts
+++ b/api/src/entity/Task.ts
@@ -25,6 +25,9 @@ export default class Task {
     @Column("boolean", { default: false })
     solved: boolean;
 
+    @Column("text", { default: null })
+    flag: string;
+
     @Column("text")
     padUrl: string;
 

--- a/api/src/migration/1615405149843-SaveFlag.ts
+++ b/api/src/migration/1615405149843-SaveFlag.ts
@@ -1,0 +1,18 @@
+import { MigrationInterface, QueryRunner } from "typeorm";
+
+export class SaveFlag1615405149843 implements MigrationInterface {
+  public async up(queryRunner: QueryRunner): Promise<void> {
+    await queryRunner.query(`ALTER TABLE "task" ADD flag text`);
+    await queryRunner.query(`ALTER TABLE "config" ADD private boolean`);
+    await queryRunner.query(`UPDATE config SET private=true WHERE key='md-create-url'`);
+    await queryRunner.query(`UPDATE config SET private=true WHERE key='md-show-url'`);
+    await queryRunner.query(`UPDATE config SET private=true WHERE key='allow-registration'`);
+    await queryRunner.query(`INSERT INTO config (key, value, private) VALUES ('store-flag', 'true', false)`);
+  }
+
+  public async down(queryRunner: QueryRunner): Promise<void> {
+    await queryRunner.query(`ALTER TABLE "task" DROP COLUMN flag`);
+    await queryRunner.query(`ALTER TABLE "config" DROP COLUMN private`);
+    await queryRunner.query(`DELETE FROM config WHERE key='store-flag'`);
+  }
+}

--- a/api/src/migration/1615405149843-SaveFlag.ts
+++ b/api/src/migration/1615405149843-SaveFlag.ts
@@ -7,7 +7,6 @@ export class SaveFlag1615405149843 implements MigrationInterface {
     await queryRunner.query(`UPDATE config SET private=true WHERE key='md-create-url'`);
     await queryRunner.query(`UPDATE config SET private=true WHERE key='md-show-url'`);
     await queryRunner.query(`UPDATE config SET private=true WHERE key='allow-registration'`);
-    await queryRunner.query(`INSERT INTO config (key, value, private) VALUES ('store-flag', 'true', false)`);
   }
 
   public async down(queryRunner: QueryRunner): Promise<void> {

--- a/front/quasar.conf.js
+++ b/front/quasar.conf.js
@@ -106,7 +106,7 @@ module.exports = function(/* ctx */) {
       // directives: [],
 
       // Quasar plugins
-      plugins: ["Notify"]
+      plugins: ["Notify", "Dialog"]
     },
 
     // animations: 'all', // --- includes all animations

--- a/front/src/api.js
+++ b/front/src/api.js
@@ -85,8 +85,8 @@ class API {
   async onIt(ctfSlug, taskSlug, onIt) {
     return this.putJson(`/ctf/${ctfSlug}/tasks/${taskSlug}/onit`, { onIt });
   }
-  async solveTask(ctfSlug, taskSlug, solved) {
-    return this.putJson(`/ctf/${ctfSlug}/tasks/${taskSlug}`, { solved });
+  async solveTask(ctfSlug, taskSlug, solved, flag) {
+    return this.putJson(`/ctf/${ctfSlug}/tasks/${taskSlug}`, { solved, flag });
   }
 
   async updateCtfPlayer(ctfSlug, playerSlug, playing) {
@@ -140,6 +140,10 @@ class API {
 
   async setConfiguration(config) {
     return this.putJson("/admin/config", config);
+  }
+
+  async getSettings() {
+    return this.get("/settings");
   }
 }
 

--- a/front/src/components/Task.vue
+++ b/front/src/components/Task.vue
@@ -30,6 +30,15 @@
                 <q-item-label class="q-px-md">Solved</q-item-label>
               </q-item-section>
             </q-item>
+            <q-item tag="label" v-ripple v-close-popup @click="showFlag" v-if="this.settings['store-flag']">
+              <q-item-section side top>
+                <q-avatar icon="flag" />
+              </q-item-section>
+
+              <q-item-section>
+                <q-item-label class="q-px-md">Show flag</q-item-label>
+              </q-item-section>
+            </q-item>
             <q-item tag="label" v-ripple v-close-popup @click="editTask = !editTask">
               <q-item-section side>
                 <q-avatar icon="edit" />
@@ -127,7 +136,7 @@ export default {
     ctf: Object
   },
   computed: {
-    ...mapGetters(["currentUser"]),
+    ...mapGetters(["currentUser", "settings"]),
 
     linkEvent() {
       return this.editTask ? "none" : "click";
@@ -143,7 +152,8 @@ export default {
       editTask: false,
       title: this.task.title,
       category: this.task.category,
-      description: this.task.description
+      description: this.task.description,
+      flag: this.task.flag
     };
   },
   mounted() {},
@@ -172,7 +182,38 @@ export default {
       this.$store.dispatch("onIt", [this.task.slug, v]);
     },
     async updateSolved(v) {
-      this.$store.dispatch("solved", [this.task.slug, v]);
+      let args = [this.task.slug, v];
+
+      if (v && this.settings["store-flag"]) {
+        this.$q
+          .dialog({
+            title: "Enter flag",
+            message: "Please enter the flag",
+            cancel: true,
+            prompt: {
+              model: '',
+              type: 'text'
+            },
+            color: "blue"
+          })
+          .onOk(data => {
+            if (data.length > 0) {
+              args.push(data);
+            }
+
+            this.$store.dispatch("solved", args);
+          }).onCancel(data => {
+            this.solved = false;
+          });
+      } else {
+        this.$store.dispatch("solved", args);
+      }
+    },
+    async showFlag() {
+      this.$q.dialog({
+        title: 'Flag for ' + this.task.title,
+        message: this.task.flag
+      })
     }
   },
   watch: {

--- a/front/src/components/Task.vue
+++ b/front/src/components/Task.vue
@@ -30,7 +30,7 @@
                 <q-item-label class="q-px-md">Solved</q-item-label>
               </q-item-section>
             </q-item>
-            <q-item tag="label" v-ripple v-close-popup @click="showFlag" v-if="this.settings['store-flag']">
+            <q-item tag="label" v-ripple v-close-popup @click="showFlag" v-if="this.settings['store-flag'] && this.task.flag != null && this.task.flag.length > 0">
               <q-item-section side top>
                 <q-avatar icon="flag" />
               </q-item-section>
@@ -212,7 +212,8 @@ export default {
     async showFlag() {
       this.$q.dialog({
         title: 'Flag for ' + this.task.title,
-        message: this.task.flag
+        message: this.task.flag,
+        color: 'blue'
       })
     }
   },

--- a/front/src/store/index.js
+++ b/front/src/store/index.js
@@ -41,6 +41,7 @@ async function handleApiCall(commit, f) {
 export default async function (/* { ssrContext } */) {
   let users = null;
   let ctfs = null;
+  let settings = null;
   let currentUser = users;
   try {
     currentUser = await api.me();
@@ -50,11 +51,13 @@ export default async function (/* { ssrContext } */) {
   if (currentUser) {
     ctfs = await api.getCtfs();
     users = await api.getUsers();
+    settings = await api.getSettings();
   }
   const Store = new Vuex.Store({
     state: {
       ctfs: ctfs,
       users: users,
+      settings: settings,
       currentUser: currentUser,
       currentCtf: null,
       currentTask: null,
@@ -65,6 +68,7 @@ export default async function (/* { ssrContext } */) {
       loading: state => state.loading,
       ctfs: state => state.ctfs,
       users: state => state.users,
+      settings: state => state.settings,
       currentUser: state => state.currentUser,
       currentCtf: state => state.currentCtf,
       currentTask: state => state.currentTask,
@@ -247,9 +251,9 @@ export default async function (/* { ssrContext } */) {
         });
       },
 
-      async solved({ commit, state }, [taskSlug, solved]) {
+      async solved({ commit, state }, [taskSlug, solved, flag]) {
         return handleApiCall(commit, async () => {
-          const task = await api.solveTask(state.currentCtf.slug, taskSlug, solved);
+          const task = await api.solveTask(state.currentCtf.slug, taskSlug, solved, flag);
           commit("updateTask", task);
         });
       },


### PR DESCRIPTION
After a task is marked as "Solved", the user is asked to enter the flag. The flag will be stored in the database and the user can open it using the context menu. If no flag is provided, nothing will be overwritten. Therefore, it is possible to solve and unsolve a task multiple times without overwriting the current flag.

A global option "store-flag" is added to enable/disable this feature. The default is true.
An API is introduced to query non-private settings, so it will also work for non-admin users.
The "store-flag" setting can also be overwritten by the environment variable CTFNOTE_STORE_FLAG.

For some more context:
We added this feature, because sometimes it is required to create a writeup with flags in order to claim a spot on the scoreboard. However, we sometimes forget to store the flags and when the challenge servers closes, we are in big trouble...
Therefore, we wanted to force our teammates to enter the flag when they mark it as solved so we will have the flag stored at least.