### PR TITLE
Remove leftover from /settings API

### DIFF
--- a/front/src/components/Task.vue
+++ b/front/src/components/Task.vue
@@ -26,7 +26,7 @@
             v-ripple
             v-close-popup
             @click="showFlag"
-            v-if="this.settings['store-flag'] && this.task.flag != null && this.task.flag.length > 0"
+            v-if="this.task.flag != null && this.task.flag.length > 0"
           >
             <q-item-section side top>
               <q-avatar icon="flag" />

--- a/front/src/store/index.js
+++ b/front/src/store/index.js
@@ -41,7 +41,6 @@ async function handleApiCall(commit, f) {
 export default async function (/* { ssrContext } */) {
   let users = null;
   let ctfs = null;
-  let settings = null;
   let currentUser = users;
   try {
     currentUser = await api.me();
@@ -51,13 +50,11 @@ export default async function (/* { ssrContext } */) {
   if (currentUser) {
     ctfs = await api.getCtfs();
     users = await api.getUsers();
-    settings = await api.getSettings();
   }
   const Store = new Vuex.Store({
     state: {
       ctfs: ctfs,
       users: users,
-      settings: settings,
       currentUser: currentUser,
       currentCtf: null,
       currentTask: null,
@@ -68,7 +65,6 @@ export default async function (/* { ssrContext } */) {
       loading: state => state.loading,
       ctfs: state => state.ctfs,
       users: state => state.users,
-      settings: state => state.settings,
       currentUser: state => state.currentUser,
       currentCtf: state => state.currentCtf,
       currentTask: state => state.currentTask,


### PR DESCRIPTION
When I tried the dev branch, I got some errors and I have already the fix:

The admin settings API is only accessible for admins, but this is called for every user. This causes blocking errors for non-admin users.

The original purpose of /settings is to deliver public settings to non-admin users. But since this has been removed, these lines should also be removed.