### PR TITLE
Migrations instead of synchronization

### DIFF
--- a/api/ormconfig.ts
+++ b/api/ormconfig.ts
@@ -13,11 +13,12 @@ const subscribersDir = path.join(baseSrcDir, "subscriber", `*.${ext}`);
 const config: ConnectionOptions = {
   type: "postgres",
   url,
-  synchronize: true,
+  synchronize: false,
   logging: false,
   entities: [entitiesDir],
   migrations: [migrationsDir],
   subscribers: [subscribersDir],
+  migrationsRun: true,
   cli: {
     entitiesDir: `${baseSrcDir}/entity`,
     migrationsDir: `${baseSrcDir}/migration`,

--- a/api/src/migration/1604351582906-CreateDatabase.ts
+++ b/api/src/migration/1604351582906-CreateDatabase.ts
@@ -4,7 +4,13 @@ export class CreateDatabase1604351582906 implements MigrationInterface {
     name = 'CreateDatabase1604351582906'
 
     public async up(queryRunner: QueryRunner): Promise<void> {
-        await queryRunner.query(`CREATE TABLE "user" ("id" SERIAL NOT NULL, "slug" text NOT NULL, "username" text NOT NULL, "password" text NOT NULL, "rights" text array NOT NULL, CONSTRAINT "UQ_ac08b39ccb744ea6682c0db1c2d" UNIQUE ("slug"), CONSTRAINT "PK_cace4a159ff9f2512dd42373760" PRIMARY KEY ("id"))`);
+        const table = await queryRunner.getTable("user");
+        if (table != null) {
+          return;
+        }
+        await queryRunner.query(
+          `CREATE TABLE "user" ("id" SERIAL NOT NULL, "slug" text NOT NULL, "username" text NOT NULL, "password" text NOT NULL, "rights" text array NOT NULL, CONSTRAINT "UQ_ac08b39ccb744ea6682c0db1c2d" UNIQUE ("slug"), CONSTRAINT "PK_cace4a159ff9f2512dd42373760" PRIMARY KEY ("id"))`
+        );
         await queryRunner.query(
           `CREATE TABLE "task" ("id" SERIAL NOT NULL, "slug" text NOT NULL, "title" text NOT NULL, "description" text, "category" text, "solved" boolean NOT NULL DEFAULT false, "padUrl" text NOT NULL, "ctfId" integer, CONSTRAINT "PK_fb213f79ee45060ba925ecd576e" PRIMARY KEY ("id"))`
         );

--- a/api/src/migration/1604351582906-CreateDatabase.ts
+++ b/api/src/migration/1604351582906-CreateDatabase.ts
@@ -5,12 +5,19 @@ export class CreateDatabase1604351582906 implements MigrationInterface {
 
     public async up(queryRunner: QueryRunner): Promise<void> {
         await queryRunner.query(`CREATE TABLE "user" ("id" SERIAL NOT NULL, "slug" text NOT NULL, "username" text NOT NULL, "password" text NOT NULL, "rights" text array NOT NULL, CONSTRAINT "UQ_ac08b39ccb744ea6682c0db1c2d" UNIQUE ("slug"), CONSTRAINT "PK_cace4a159ff9f2512dd42373760" PRIMARY KEY ("id"))`);
-        await queryRunner.query(`CREATE TABLE "task" ("id" SERIAL NOT NULL, "slug" text NOT NULL, "title" text NOT NULL, "description" text, "category" text, "solved" boolean NOT NULL DEFAULT false, "padUrl" text NOT NULL, "ctfId" integer, CONSTRAINT "UQ_7e28b6f481038cc247d976df847" UNIQUE ("ctfId", "slug"), CONSTRAINT "PK_fb213f79ee45060ba925ecd576e" PRIMARY KEY ("id"))`);
-        await queryRunner.query(`CREATE TABLE "ctf" ("id" SERIAL NOT NULL, "slug" text NOT NULL, "title" text NOT NULL, "weight" double precision, "ctfUrl" text, "logoUrl" text, "ctfTimeUrl" text, "format" text, "description" text, "start" date, "finish" date, CONSTRAINT "UQ_eaa0cd7d65a5bd07b22a205327d" UNIQUE ("slug"), CONSTRAINT "PK_dd96b4bb673395d250d1c3bb056" PRIMARY KEY ("id"))`);
+        await queryRunner.query(
+          `CREATE TABLE "task" ("id" SERIAL NOT NULL, "slug" text NOT NULL, "title" text NOT NULL, "description" text, "category" text, "solved" boolean NOT NULL DEFAULT false, "padUrl" text NOT NULL, "ctfId" integer, CONSTRAINT "PK_fb213f79ee45060ba925ecd576e" PRIMARY KEY ("id"))`
+        );
+        await queryRunner.query(
+          `CREATE TABLE "ctf" ("id" SERIAL NOT NULL, "slug" text NOT NULL, "title" text NOT NULL, "weight" double precision, "ctfUrl" text, "logoUrl" text, "ctfTimeUrl" text, "format" text, "description" text, "credentials" text, "start" TIMESTAMP, "finish" TIMESTAMP, CONSTRAINT "UQ_eaa0cd7d65a5bd07b22a205327d" UNIQUE ("slug"), CONSTRAINT "PK_dd96b4bb673395d250d1c3bb056" PRIMARY KEY ("id"))`
+        );
         await queryRunner.query(`CREATE TABLE "session" ("id" SERIAL NOT NULL, "userSlug" text NOT NULL, "uuid" text NOT NULL, "expiresAt" date NOT NULL, CONSTRAINT "PK_f55da76ac1c3ac420f444d2ff11" PRIMARY KEY ("id"))`);
         await queryRunner.query(`CREATE TABLE "task_players_user" ("taskId" integer NOT NULL, "userId" integer NOT NULL, CONSTRAINT "PK_a339a92e17f22b8e4dbf7fdc34d" PRIMARY KEY ("taskId", "userId"))`);
-        await queryRunner.query(`CREATE INDEX "IDX_344584ea16e58334c4baf25fab" ON "task_players_user" ("taskId") `);
-        await queryRunner.query(`CREATE INDEX "IDX_3d63c39f2ccb2bf5cb68df2f9f" ON "task_players_user" ("userId") `);
+        await queryRunner.query(
+          `CREATE TABLE "config" ("id" SERIAL NOT NULL, "key" text NOT NULL, "value" json NOT NULL, CONSTRAINT "UQ_26489c99ddbb4c91631ef5cc791" UNIQUE ("key"), CONSTRAINT "PK_d0ee79a681413d50b0a4f98cf7b" PRIMARY KEY ("id"))`
+        );
+        await queryRunner.query(`CREATE UNIQUE INDEX "IDX_7e28b6f481038cc247d976df84" ON "task" ("ctfId", "slug")`);
+        await queryRunner.query(`CREATE INDEX "IDX_344584ea16e58334c4baf25fab" ON "task_players_user" ("taskId")`);
         await queryRunner.query(`CREATE TABLE "ctf_guests_user" ("ctfId" integer NOT NULL, "userId" integer NOT NULL, CONSTRAINT "PK_591b8ad1033aa94261f75948c9b" PRIMARY KEY ("ctfId", "userId"))`);
         await queryRunner.query(`CREATE INDEX "IDX_1fc356c5f6ba10ee718534e883" ON "ctf_guests_user" ("ctfId") `);
         await queryRunner.query(`CREATE INDEX "IDX_7f12bda4d0766d864e9632693f" ON "ctf_guests_user" ("userId") `);
@@ -32,11 +39,13 @@ export class CreateDatabase1604351582906 implements MigrationInterface {
         await queryRunner.query(`DROP TABLE "ctf_guests_user"`);
         await queryRunner.query(`DROP INDEX "IDX_3d63c39f2ccb2bf5cb68df2f9f"`);
         await queryRunner.query(`DROP INDEX "IDX_344584ea16e58334c4baf25fab"`);
+        await queryRunner.query(`DROP INDEX "IDX_7e28b6f481038cc247d976df84"`);
         await queryRunner.query(`DROP TABLE "task_players_user"`);
         await queryRunner.query(`DROP TABLE "session"`);
         await queryRunner.query(`DROP TABLE "ctf"`);
         await queryRunner.query(`DROP TABLE "task"`);
         await queryRunner.query(`DROP TABLE "user"`);
+        await queryRunner.query(`DROP TABLE "config"`);
     }
 
 }

--- a/api/src/migration/1615405149843-SaveFlag.ts
+++ b/api/src/migration/1615405149843-SaveFlag.ts
@@ -3,15 +3,9 @@ import { MigrationInterface, QueryRunner } from "typeorm";
 export class SaveFlag1615405149843 implements MigrationInterface {
   public async up(queryRunner: QueryRunner): Promise<void> {
     await queryRunner.query(`ALTER TABLE "task" ADD flag text`);
-    await queryRunner.query(`ALTER TABLE "config" ADD private boolean`);
-    await queryRunner.query(`UPDATE config SET private=true WHERE key='md-create-url'`);
-    await queryRunner.query(`UPDATE config SET private=true WHERE key='md-show-url'`);
-    await queryRunner.query(`UPDATE config SET private=true WHERE key='allow-registration'`);
   }
 
   public async down(queryRunner: QueryRunner): Promise<void> {
     await queryRunner.query(`ALTER TABLE "task" DROP COLUMN flag`);
-    await queryRunner.query(`ALTER TABLE "config" DROP COLUMN private`);
-    await queryRunner.query(`DELETE FROM config WHERE key='store-flag'`);
   }
 }

--- a/api/src/migration/1615405149843-SaveFlag.ts
+++ b/api/src/migration/1615405149843-SaveFlag.ts
@@ -2,7 +2,11 @@ import { MigrationInterface, QueryRunner } from "typeorm";
 
 export class SaveFlag1615405149843 implements MigrationInterface {
   public async up(queryRunner: QueryRunner): Promise<void> {
-    await queryRunner.query(`ALTER TABLE "task" ADD flag text`);
+    const table = await queryRunner.getTable("task");
+    if (table.findColumnByName("flag")) {
+      return;
+    }
+    await queryRunner.query(`ALTER TABLE "task" ADD flag text`);  
   }
 
   public async down(queryRunner: QueryRunner): Promise<void> {


### PR DESCRIPTION
Migrations are a safer way of changing the database. The docs of TypeORM states that synchronize should only be used in development. However, currently it is used in production.

Now it has been changed to only migrations so no data loss could ever happen. The existing migrations are fixed to reflect the current dev branch.

It could be possible that current databases are not compatibly with the migrations. This is because both migrations already happened but not recorded in the database. A fail-safe is implemented for this, so it will skip migrations.
