### PR TITLE
Add Hedgedoc authentication

### DIFF
--- a/api/src/config/globals.ts
+++ b/api/src/config/globals.ts
@@ -15,6 +15,9 @@ export default class Globals {
   static cookieName = "ctfnote-auth";
   static userAgent = "CTFNote";
 
+  static hedgedocCookieName = "connect.sid";
+  static hedgedocAuth = process.env.MD_AUTH == "true" || true;
+
   static adminRights = [Rights.ADMIN_ALL];
   static defaultRights = [];
 
@@ -36,5 +39,6 @@ export default class Globals {
       "allow-registration",
       Globals.allowRegistration
     );
+    Globals.hedgedocAuth = await PersistentConfiguration.setIfNotSet("hedgedoc-auth", Globals.hedgedocAuth);
   }
 }

--- a/api/src/controllers/auth.controller/logout.action.ts
+++ b/api/src/controllers/auth.controller/logout.action.ts
@@ -12,6 +12,7 @@ const LogoutAction: IRoute = {
 
     if (logout) await SessionManager.invalidateSession(req.cookies[Globals.cookieName]);
 
+    res.clearCookie(Globals.hedgedocCookieName);
     return res.status(204).send();
   },
 };

--- a/api/src/controllers/config.controller/update.action.ts
+++ b/api/src/controllers/config.controller/update.action.ts
@@ -19,11 +19,13 @@ const UpdateConfigAction: IRoute = {
       "md-create-url": mdCreateUrl,
       "md-show-url": mdShowUrl,
       "allow-registration": allowRegistration,
+      "hedgedoc-auth": hedgedocAuth,
     } = req.body;
 
     if (mdCreateUrl != null) await PersistentConfiguration.set("md-create-url", mdCreateUrl);
     if (mdShowUrl != null) await PersistentConfiguration.set("md-show-url", mdShowUrl);
     if (allowRegistration != null) await PersistentConfiguration.set("allow-registration", allowRegistration);
+    if (hedgedocAuth != null) await PersistentConfiguration.set("hedgedoc-auth", hedgedocAuth);
 
     return res.status(200).json(await PersistentConfiguration.list());
   },

--- a/api/src/services/pad.ts
+++ b/api/src/services/pad.ts
@@ -1,6 +1,8 @@
 import Axios from "axios";
 import logger from "../config/logger";
 import PersistentConfiguration from "../config/persitent";
+import querystring from "querystring";
+import Globals from "../config/globals";
 
 export default class PadService {
   /**
@@ -21,5 +23,59 @@ export default class PadService {
       logger.fatal(e);
       return "#";
     }
+  }
+
+  private static async baseUrl(): Promise<string> {
+    let cleanUrl: string = await PersistentConfiguration.get("md-create-url");
+    cleanUrl = cleanUrl.slice(0, -4); //remove '/new' for clean url
+    return cleanUrl;
+  }
+
+  private static async authPad(username: string, password: string, url: URL): Promise<string> {
+    if (!Globals.hedgedocAuth) {
+      return null;
+    }
+
+    let domain: string;
+    //if domain does not end in '.[tld]', it will be rejected
+    //so we add '.local' manually
+    if (url.hostname.split(".").length == 1) {
+      domain = `${url.hostname}.local`;
+    } else {
+      domain = url.hostname;
+    }
+
+    const email = `${username}@${domain}`;
+
+    try {
+      const res = await Axios.post(
+        url.toString(),
+        querystring.stringify({
+          email: email,
+          password: password,
+        }),
+        {
+          validateStatus: (status) => status === 302,
+          maxRedirects: 0,
+          timeout: 5000,
+          headers: { "Content-Type": "application/x-www-form-urlencoded" },
+        }
+      );
+      return res.headers["set-cookie"];
+    } catch (e) {
+      logger.warn(`Could not auth to pad service: '${url.toString()}': `);
+      logger.fatal(e);
+      return null;
+    }
+  }
+
+  static async register(username: string, password: string): Promise<string> {
+    const authUrl = new URL(`${await this.baseUrl()}/register`);
+    return this.authPad(username, password, authUrl);
+  }
+
+  static async login(username: string, password: string): Promise<string> {
+    const authUrl = new URL(`${await this.baseUrl()}/login`);
+    return this.authPad(username, password, authUrl);
   }
 }


### PR DESCRIPTION
When a new account is created, CTFNote now tries to register the user to Hedgedoc. After that, the user will be automatically authenticated to Hedgedoc when logging in. The slug and password of the user are used for registering.

Only new accounts are registered to Hedgedoc. However, on every log in CTFNote tries to authenticate the user to Hedgedoc. This does not cause an error.

The benefit of authenticating is that the cursor of the user shows the username/slug and changes by users are shown by Hedgedoc.

The slug is used instead of the username because the slug never changes for a user. If the username was used and it changes, then authentication will always fail on login.

This feature can be disabled by the env variable MD_AUTH.

No new URL is required, because the MD create url is used for building the URL.