### PR TITLE
Added time left indicator

### DIFF
--- a/front/src/components/CtfInfo.vue
+++ b/front/src/components/CtfInfo.vue
@@ -68,7 +68,17 @@
         <div class="ctfcard-cal col-auto col-grow">
           <div class="column items-center q-gutter-sm">
             <q-date today-btn :subtitle="getTimeStart(ctf)" :value="getDateRange(ctf)" range />
-            <Timer :date="ctf.start" />
+            <div class="text-center">
+              <div v-if="(new Date(ctf.start)).getTime() > new Date().getTime()">
+                Starts in
+                <Timer :date="ctf.start" />
+              </div>
+              
+              <div v-else>
+                Time left
+                <Timer :date="ctf.finish" />
+              </div>
+            </div>
           </div>
         </div>
       </div>


### PR DESCRIPTION
Added indicator so that it shows not only the time until the CTF starts but also the time left during a CTF. Been a while since I touched Vue so I'm a bit rusty, but can't see any reason this shouldn't work. 

Edit: It does add some visual noise, but feel like the time left is the more useful stat of the two :)

![image showing the time left countdown](https://s.skye.to/2104/firefox-Qh0oX8ZZ3nFGJUou.png)