### PR TITLE
Change players-tooltip and add player-chips back

### DIFF
--- a/front/src/components/CTF/PlayerTooltip.vue
+++ b/front/src/components/CTF/PlayerTooltip.vue
@@ -1,0 +1,45 @@
+<template>
+  <q-tooltip anchor="top right" self="top left" :offset="[0, 0]" content-class="transparent" v-if="players.length">
+    <q-card dense bordered>
+      <q-card-section class="tooltip-section">
+        <q-list dense>
+          <q-item tag="label" :key="player.nodeId" v-for="player in players">
+            <q-item-section class="text-center">
+              <q-chip class="text-white text-center" :style="taskStyle(player.nodeId)">
+                <div class="text-center full-width">
+                  {{ player.username }}
+                </div>
+              </q-chip>
+            </q-item-section>
+          </q-item>
+        </q-list>
+      </q-card-section>
+    </q-card>
+  </q-tooltip>
+</template>
+
+<script>
+import { colorHash } from "../../utils";
+export default {
+  props: {
+    task: { type: Object, required: true }
+  },
+  methods: {
+    taskStyle(s) {
+      return { backgroundColor: colorHash(s) };
+    }
+  },
+  computed: {
+    players() {
+      return this.task.workOnTasks.nodes.map(n => n.profile);
+    }
+  }
+};
+</script>
+
+<style lang="scss" scoped>
+.tooltip-section,
+.tooltip-section label {
+  padding: 2px 4px !important;
+}
+</style>

--- a/front/src/components/CTF/TaskCard.vue
+++ b/front/src/components/CTF/TaskCard.vue
@@ -50,29 +50,7 @@
       <q-card-section>
         <q-badge v-if="showBadge" class="solved-badge" floating :color="$ctfnote.taskIconColor(task)">
           <q-icon :name="$ctfnote.taskIcon(task)" />
-          <q-tooltip
-            anchor="top right"
-            self="top left"
-            :offset="[0, 0]"
-            content-class="transparent"
-            v-if="players.length"
-          >
-            <q-card dense bordered>
-              <q-card-section class="tooltip-section">
-                <q-list dense>
-                  <q-item tag="label" :key="player.slug" v-for="player in players">
-                    <q-item-section class="text-center">
-                      <q-chip class="text-white text-center" :style="taskStyle(player.slug)">
-                        <div class="text-center full-width">
-                          {{ player.username }}
-                        </div>
-                      </q-chip>
-                    </q-item-section>
-                  </q-item>
-                </q-list>
-              </q-card-section>
-            </q-card>
-          </q-tooltip>
+          <player-tooltip :task="task"></player-tooltip>
         </q-badge>
         <div class="row justify-between">
           <router-link class="text-h6 col tasklink" tag="a" :to="$ctfnote.taskLink(ctf, task)">
@@ -91,6 +69,15 @@
         </div>
       </q-card-section>
       <q-separator inset v-if="!isUltraDense" />
+      <q-card-section v-if="!isUltraDense">
+        <q-chip
+          :label="player.username"
+          :key="player.nodeId"
+          class="text-white"
+          :style="taskStyle(player.nodeId)"
+          v-for="player in players"
+        />
+      </q-card-section>
       <q-card-section v-if="!isUltraDense">
         <p class="task-description">
           {{ task.description || "..." }}
@@ -115,7 +102,9 @@
 
 <script>
 import { colorHash } from "../../utils";
+import PlayerTooltip from "./PlayerTooltip.vue";
 export default {
+  components: { PlayerTooltip },
   props: {
     task: { type: Object, required: true },
     ctf: { type: Object, required: true },
@@ -220,10 +209,5 @@ export default {
       box-shadow: 0px 0px 5px rgba(25, 25, 25, 0.8);
     }
   }
-}
-
-.tooltip-section,
-.tooltip-section label {
-  padding: 2px 4px !important;
 }
 </style>

--- a/front/src/components/LeftMenuCategoryList.vue
+++ b/front/src/components/LeftMenuCategoryList.vue
@@ -9,6 +9,7 @@
         </q-item-section>
         <q-item-section avatar>
           <q-icon :color="$ctfnote.taskIconColor(task)" :name="$ctfnote.taskIcon(task)" />
+          <player-tooltip :task="task"></player-tooltip>
         </q-item-section>
       </q-item>
     </q-list>
@@ -17,7 +18,9 @@
 
 <script>
 import { colorHash } from "../utils";
+import PlayerTooltip from './CTF/PlayerTooltip.vue';
 export default {
+	components: { PlayerTooltip },
   props: {
     ctf: { type: Object, required: true },
     title: { type: String, required: true },
@@ -28,7 +31,7 @@ export default {
   },
   computed: {
     style() {
-      return { fontWeight: "bold", backgroundColor: colorHash(this.title) };
+      return { fontWeight: "bold", backgroundColor: colorHash(this.title), color: "white" };
     }
   }
 };


### PR DESCRIPTION
The active-players-on-this-task tooltip is now a separate component.
This is done because it is now used in two places:
1. In the top right corner of every task
2. In the drawer menu list of all tasks
(2) is newly introduced in this branch. This is added because it is also
a helpful place to show this information.
You can trigger it by hovering on the icon in the list.

Also, the player chips are added back again. I did this because I really
liked the idea to see (without hovering over every task) who is working
on what. This is very useful information so, for example, I know within
seconds which voice channel to join in Discord.
Otherwise, I would have to hover over each task to check who is doing what.
The chips are not shown in ultradense mode.

This commit also fixes two minor issues:
1. player.slug doesn't exist anymore (is undefined) and therefore
the color hash would be always the same for every player.
2. The category text was black in the drawer list. However, the color hash
often outputs dark colors, so now the font color is white.

I also want to say: AMAZING work is in the `graphql` branch! I really like
what is done and I would love to see this in master soon :)