### PR TITLE
Wait for queries before removing loader

### DIFF
--- a/front/src/App.vue
+++ b/front/src/App.vue
@@ -2,16 +2,24 @@
   <router-view />
 </template>
 <script lang="ts">
-import { defineComponent } from 'vue';
+import { useGlobalQueryLoading } from '@vue/apollo-composable';
+import { defineComponent, watch } from 'vue';
 
 export default defineComponent({
   name: 'App',
   mounted() {
-    const loadingscreen = document.getElementById('loadingscreen');
-    if (loadingscreen) {
-      loadingscreen.classList.add('fadeout');
-      window.setTimeout(() => (loadingscreen.style.display = 'none'), 1500);
-    }
+    const loading = useGlobalQueryLoading();
+    watch(
+      loading,
+      (isLoading) => {
+        if (!isLoading) {
+          const loadingscreen = document.getElementById('loadingscreen');
+          if (!loadingscreen) return;
+          loadingscreen.classList.add('fadeout');
+          window.setTimeout(() => (loadingscreen.style.display = 'none'), 1500);
+        }
+      }
+    );
   },
 });
 </script>

--- a/front/src/components/CTF/CardList.vue
+++ b/front/src/components/CTF/CardList.vue
@@ -5,15 +5,23 @@
       :key="idx"
       class="column col q-gutter-lg justify-start align-center"
     >
-      <div v-for="ctf in column" :key="ctf.nodeId">
-        <card :ctf="ctf" />
-      </div>
+      <q-intersection
+        v-for="ctf in column"
+        :key="ctf.nodeId"
+        once
+        style="min-height: 550px;"
+        transition="fade"
+      >
+        <div>
+          <card :ctf="ctf" />
+        </div>
+      </q-intersection>
     </div>
   </div>
 </template>
 
 <script lang="ts">
-import { Ctf } from 'src/ctfnote';
+import { Ctf } from 'src/ctfnote/models';
 import { defineComponent } from 'vue';
 import Card from './Card.vue';
 export default defineComponent({

--- a/front/src/index.template.html
+++ b/front/src/index.template.html
@@ -52,7 +52,7 @@
         position: fixed;
         top: 0;
         left: 0;
-        transition: transform  ease-out .5s .2s;
+        transition: transform  ease-out .5s ;
         z-index: 100000;
       }
 


### PR DESCRIPTION
The page loader was sliding out
 as soon as "me" and the "settings are retrieved

 Now it also wait for all graphql queries return