### PR TITLE
Hedgedoc: upgrade to version 1.9.2

### DIFF
--- a/docker-compose.dev.yml
+++ b/docker-compose.dev.yml
@@ -15,7 +15,7 @@ services:
     ports:
       - '5432:5432'
   hedgedoc:
-    image: quay.io/hedgedoc/hedgedoc:1.9.0-alpine
+    image: quay.io/hedgedoc/hedgedoc:1.9.2-alpine
     environment:
       - CMD_DB_URL=postgres://ctfnote:ctfnote@db:5432/hedgedoc
       - CMD_URL_PATH=pad

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -42,7 +42,7 @@ services:
     ports:
       - 8080:80
   hedgedoc:
-    image: quay.io/hedgedoc/hedgedoc:1.9.0-alpine
+    image: quay.io/hedgedoc/hedgedoc:1.9.2-alpine
     environment:
       - CMD_DB_URL=postgres://ctfnote:ctfnote@db:5432/hedgedoc
       - CMD_URL_PATH=pad


### PR DESCRIPTION
https://github.com/hedgedoc/hedgedoc/releases/tag/1.9.2
https://github.com/hedgedoc/hedgedoc/releases/tag/1.9.1