### PR TITLE
Move solved tasks to end of list, add filter for own tasks

### DIFF
--- a/front/src/components/Task/TaskList.vue
+++ b/front/src/components/Task/TaskList.vue
@@ -235,7 +235,7 @@ export default defineComponent({
           }
           return acat < bcat ? -1 : 1;
         })
-        .sort((a, b) => {
+        .sort((a) => {
           return a.solved ? 1 : -1;
         });
     },

--- a/front/src/components/Task/TaskList.vue
+++ b/front/src/components/Task/TaskList.vue
@@ -28,6 +28,7 @@
       </div>
       <div class="col col-auto">
         <q-checkbox v-model="hideSolved" label="Hide solved" />
+        <q-checkbox v-model="myTasks" label="Show my tasks" />
       </div>
       <q-space />
       <div class="col col-1">
@@ -121,6 +122,7 @@ export default defineComponent({
 
     const updateTask = ctfnote.tasks.useUpdateTask();
     const deleteTask = ctfnote.tasks.useDeleteTask();
+    const me = ctfnote.me.injectMe();
 
     provide(keys.solveTaskPopup, (task: Task) => {
       $q.dialog({
@@ -168,11 +170,15 @@ export default defineComponent({
     const filter = ref('');
     const categoryFilter = ref<string[]>([]);
     const hideSolved = makePersistant('task-hide-solved', ref(false));
+    const myTasks = makePersistant('task-my-tasks', ref(false));
 
     provide(keys.isTaskVisible, (task: Task) => {
       const needle = filter.value.toLowerCase();
       // Hide solved task if hideSolved == true
       if (hideSolved.value && task.solved) return false;
+
+      if (myTasks.value && task.workOnTasks.indexOf(me.value.profile.id) === -1)
+        return false;
 
       // Hide task if there is a filter and category not in filter
       const catFilter = categoryFilter.value;
@@ -198,9 +204,11 @@ export default defineComponent({
     return {
       displayMode: makePersistant('task-display-mode', ref('classic')),
       hideSolved,
+      myTasks,
       filter,
       categoryFilter,
       displayOptions,
+      me,
     };
   },
   computed: {
@@ -215,16 +223,21 @@ export default defineComponent({
     },
     sortedTasks() {
       const tasks = this.tasks;
-      return tasks.slice().sort((a, b) => {
-        const acat = (a.category ?? '').toLowerCase();
-        const bcat = (b.category ?? '').toLowerCase();
-        if (acat == bcat) {
-          const atitle = a.title.toLowerCase();
-          const btitle = a.title.toLowerCase();
-          return atitle == btitle ? 0 : atitle < btitle ? -1 : 1;
-        }
-        return acat < bcat ? -1 : 1;
-      });
+      return tasks
+        .slice()
+        .sort((a, b) => {
+          const acat = (a.category ?? '').toLowerCase();
+          const bcat = (b.category ?? '').toLowerCase();
+          if (acat == bcat) {
+            const atitle = a.title.toLowerCase();
+            const btitle = a.title.toLowerCase();
+            return atitle == btitle ? 0 : atitle < btitle ? -1 : 1;
+          }
+          return acat < bcat ? -1 : 1;
+        })
+        .sort((a, b) => {
+          return a.solved ? 1 : -1;
+        });
     },
   },
   methods: {

--- a/front/src/components/Utils/TaskListMenu.vue
+++ b/front/src/components/Utils/TaskListMenu.vue
@@ -76,16 +76,21 @@ export default defineComponent({
       return 'Open task';
     },
     sortedTasks() {
-      return this.ctf.tasks.slice().sort((a, b) => {
-        const acat = (a.category ?? '').toLowerCase();
-        const bcat = (b.category ?? '').toLowerCase();
-        if (acat == bcat) {
-          const atitle = a.title.toLowerCase();
-          const btitle = a.title.toLowerCase();
-          return atitle == btitle ? 0 : atitle < btitle ? -1 : 1;
-        }
-        return acat < bcat ? -1 : 1;
-      });
+      return this.ctf.tasks
+        .slice()
+        .sort((a, b) => {
+          const acat = (a.category ?? '').toLowerCase();
+          const bcat = (b.category ?? '').toLowerCase();
+          if (acat == bcat) {
+            const atitle = a.title.toLowerCase();
+            const btitle = a.title.toLowerCase();
+            return atitle == btitle ? 0 : atitle < btitle ? -1 : 1;
+          }
+          return acat < bcat ? -1 : 1;
+        })
+        .sort((a, b) => {
+          return a.solved ? 1 : -1;
+        });
     },
   },
   methods: {

--- a/front/src/components/Utils/TaskListMenu.vue
+++ b/front/src/components/Utils/TaskListMenu.vue
@@ -88,7 +88,7 @@ export default defineComponent({
           }
           return acat < bcat ? -1 : 1;
         })
-        .sort((a, b) => {
+        .sort((a) => {
           return a.solved ? 1 : -1;
         });
     },


### PR DESCRIPTION
If a task is solved, it is moved to the bottom of the view to prioritize the tasks that are not solved yet.

There is also a new checkbox introduced: 'Show my tasks'. This will show only the tasks that you have assigned yourself to.

The 'Hide solved' checkbox now only makes the list shorter, but it is still nice to have.

This is already discussed [here](https://github.com/TFNS/CTFNote/discussions/102#discussioncomment-1541805).

I decided to not implement pinning since it causes confusion when you click the button: it appears that the task has not been marked as 'on it', but actually the row is swapped with a different task because of the ordering. Instead of pinning, I added the 'Show my tasks' filter.