### PR TITLE
Update 36-split-me-and-new-jwt.sql

### DIFF
--- a/api/migrations/36-split-me-and-new-jwt.sql
+++ b/api/migrations/36-split-me-and-new-jwt.sql
@@ -1,4 +1,4 @@
-DROP FUNCTION me;
+DROP FUNCTION ctfnote.me;
 
 CREATE OR REPLACE FUNCTION ctfnote.me ()
   RETURNS ctfnote.profile


### PR DESCRIPTION
Fix migration error: could not find a function named "me".
I had the above error when running this sql file on a cloud database, hopefully this commit fixes it.