### PR TITLE
Fixed URI in ctfd importer hint

### DIFF
--- a/front/src/ctfnote/parsers/ctfd.ts
+++ b/front/src/ctfnote/parsers/ctfd.ts
@@ -3,7 +3,7 @@ import { parseJson, parseJsonStrict } from '../utils';
 
 const CTFDParser: Parser = {
   name: 'CTFd parser',
-  hint: 'paste ctfd /api/v1/challenge',
+  hint: 'paste ctfd /api/v1/challenges',
 
   parse(s: string): ParsedTask[] {
     const tasks = [];


### PR DESCRIPTION
Hey there!

This just fixes a small typo in the CTFd importer hint.
The correct URI is `/api/v1/challenges`, according to https://docs.ctfd.io/docs/api/swagger-ui