### PR TITLE
Unpin Hedgedoc

### DIFF
--- a/docker-compose.dev.yml
+++ b/docker-compose.dev.yml
@@ -15,7 +15,7 @@ services:
     ports:
       - '5432:5432'
   hedgedoc:
-    image: quay.io/hedgedoc/hedgedoc@sha256:8df47646f2c58959921d2b7719a6f3023441bdb7435040aa3c32abe6145095f6
+    image: quay.io/hedgedoc/hedgedoc:1.9.4
     environment:
       CMD_DB_URL: 'postgres://ctfnote:ctfnote@db:5432/hedgedoc'
       CMD_URL_PATH: 'pad'

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -42,7 +42,7 @@ services:
     ports:
       - 8080:80
   hedgedoc:
-    image: quay.io/hedgedoc/hedgedoc@sha256:8df47646f2c58959921d2b7719a6f3023441bdb7435040aa3c32abe6145095f6
+    image: quay.io/hedgedoc/hedgedoc:1.9.4
     environment:
       - CMD_DB_URL=postgres://ctfnote:ctfnote@db:5432/hedgedoc
       - CMD_URL_PATH=pad


### PR DESCRIPTION
Follow-up of the problem #173 
Hedgedoc's build system removes untagged containers -- we cannot rely on them for pinning.