### PR TITLE
API: Pin dicer to v0.3.1

### DIFF
--- a/api/package.json
+++ b/api/package.json
@@ -43,5 +43,8 @@
     "ts-node": "^10.9.1",
     "tslint": "^6.1.3",
     "typescript": "^4.7.4"
+  },
+  "resolutions": {
+    "graphql-upload/busboy/dicer": "0.3.1"
   }
 }

--- a/api/yarn.lock
+++ b/api/yarn.lock
@@ -821,7 +821,7 @@ destroy@1.2.0:
   resolved "https://registry.yarnpkg.com/destroy/-/destroy-1.2.0.tgz#4803735509ad8be552934c67df614f94e66fa015"
   integrity sha512-2sJGJTaXIIaR1w4iJSNoN0hnMY7Gpc/n8D4qSCJw8QqFWXf7cuAgnEHxBpweaVcPevC2l3KpjYCx3NypQQgaJg==
 
-dicer@0.3.1:
+dicer@0.3.0, dicer@0.3.1:
   version "0.3.1"
   resolved "https://registry.yarnpkg.com/dicer/-/dicer-0.3.1.tgz#abf28921e3475bc5e801e74e0159fd94f927ba97"
   integrity sha512-ObioMtXnmjYs3aRtpIJt9rgQSPCIhKVkFPip+E9GUDyWl8N435znUxK/JfNwGZJ2wnn5JKQ7Ly3vOK5Q5dylGA==


### PR DESCRIPTION
Current fix required to edit the lock file by hand.
This commit adds a "resolutions" key to the package.json file.
This pins this specific dependency to version 0.3.1 without using dubious hacks.

More info about this feature:
https://classic.yarnpkg.com/lang/en/docs/selective-version-resolutions/


On a different topic : can you rebase PR instead of merging them ? (Click on the downward-pointing arrow before merging)
This makes a prettier git history