### PR TITLE
Front: upgrade outdated sub-dependencies

### DIFF
--- a/front/package.json
+++ b/front/package.json
@@ -68,5 +68,9 @@
     "node": ">= 12.22.1",
     "npm": ">= 6.13.4",
     "yarn": ">= 1.21.1"
+  },
+  "resolutions": {
+    "eslint-plugin-graphql/graphql-config/@graphql-tools/url-loader/cross-fetch": "3.1.5",
+    "eslint-plugin-graphql/graphql-config/@graphql-tools/url-loader/ws": "7.4.6"
   }
 }

--- a/front/yarn.lock
+++ b/front/yarn.lock
@@ -3807,14 +3807,7 @@ create-require@^1.1.0:
   resolved "https://registry.yarnpkg.com/create-require/-/create-require-1.1.1.tgz#c1d7e8f1e5f6cfc9ff65f9cd352d37348756c333"
   integrity sha512-dcKFX3jn0MpIaXjisoRvexIJVEKzaq7z2rZKxf+MSr9TkdmHmsU4m2lcLojrj/FHl8mk5VxMmYA+ftRkP/3oKQ==
 
-cross-fetch@3.1.4:
-  version "3.1.4"
-  resolved "https://registry.yarnpkg.com/cross-fetch/-/cross-fetch-3.1.4.tgz#9723f3a3a247bf8b89039f3a380a9244e8fa2f39"
-  integrity sha512-1eAtFWdIubi6T4XPy6ei9iUFoKpUkIF971QLN8lIvvvwueI65+Nw5haMNKUwfJxabqlIIDODJKGrQ66gxC0PbQ==
-  dependencies:
-    node-fetch "2.6.1"
-
-cross-fetch@^3.1.5:
+cross-fetch@3.1.4, cross-fetch@3.1.5, cross-fetch@^3.1.5:
   version "3.1.5"
   resolved "https://registry.yarnpkg.com/cross-fetch/-/cross-fetch-3.1.5.tgz#e1389f44d9e7ba767907f7af8454787952ab534f"
   integrity sha512-lvb1SBsI0Z7GDwmuid+mU3kWVBwTVUbe7S0H52yaaAdQOXq2YktTCZdlAcNKFzE6QtRz0snpw9bNiPeOIkkQvw==
@@ -6862,11 +6855,6 @@ node-domexception@1.0.0:
   resolved "https://registry.yarnpkg.com/node-domexception/-/node-domexception-1.0.0.tgz#6888db46a1f71c0b76b3f7555016b63fe64766e5"
   integrity sha512-/jKZoMpw0F8GRwl4/eLROPA3cfcXtLApP0QzLmUT/HuPCZWyB7IY9ZrMeKw2O/nFIqPQB3PVM9aYm0F312AXDQ==
 
-node-fetch@2.6.1:
-  version "2.6.1"
-  resolved "https://registry.yarnpkg.com/node-fetch/-/node-fetch-2.6.1.tgz#045bd323631f76ed2e2b55573394416b639a0052"
-  integrity sha512-V4aYg89jEoVRxRb2fJdAg8FHvI7cEyYdVAh94HH0UIK8oJxUfkjlDQN9RbMx+bEjP7+ggMiFRprSti032Oipxw==
-
 node-fetch@2.6.7, node-fetch@^2.6.1, node-fetch@^2.6.7:
   version "2.6.7"
   resolved "https://registry.yarnpkg.com/node-fetch/-/node-fetch-2.6.7.tgz#24de9fba827e3b4ae44dc8b20256a379160052ad"
@@ -9554,10 +9542,10 @@ write-file-atomic@^3.0.0:
     signal-exit "^3.0.2"
     typedarray-to-buffer "^3.1.5"
 
-ws@7.4.5:
-  version "7.4.5"
-  resolved "https://registry.yarnpkg.com/ws/-/ws-7.4.5.tgz#a484dd851e9beb6fdb420027e3885e8ce48986c1"
-  integrity sha512-xzyu3hFvomRfXKH8vOFMU3OguG6oOvhXMo3xsGy3xWExqaM2dxBbVxuD99O7m3ZUFMvvscsZDqxfgMaRr/Nr1g==
+ws@7.4.5, ws@7.4.6:
+  version "7.4.6"
+  resolved "https://registry.yarnpkg.com/ws/-/ws-7.4.6.tgz#5654ca8ecdeee47c33a9a4bf6d28e2be2980377c"
+  integrity sha512-YmhHDO4MzaDLB+M9ym/mDA5z0naX8j7SIlT8f8z+I0VtzsRbekxEutHSme7NPS2qE8StCYQNUnfWdXta/Yu85A==
 
 "ws@^5.2.0 || ^6.0.0 || ^7.0.0", ws@^7.3.1:
   version "7.5.9"


### PR DESCRIPTION
I do not know how to test that. At least it still builds :D

We still have @quasar/cli's dependencies, but those are too ancient to be upgraded it seems.

```
┌───────────────┬──────────────────────────────────────────────────────────────┐
│ moderate      │ Got allows a redirect to a UNIX socket                       │
├───────────────┼──────────────────────────────────────────────────────────────┤
│ Package       │ got                                                          │
├───────────────┼──────────────────────────────────────────────────────────────┤
│ Patched in    │ >=11.8.5                                                     │
├───────────────┼──────────────────────────────────────────────────────────────┤
│ Dependency of │ @quasar/cli                                                  │
├───────────────┼──────────────────────────────────────────────────────────────┤
│ Path          │ @quasar/cli > download-git-repo > download > got             │
├───────────────┼──────────────────────────────────────────────────────────────┤
│ More info     │ https://www.npmjs.com/advisories/1080920                     │
└───────────────┴──────────────────────────────────────────────────────────────┘
```
[@quasar/cli](https://www.npmjs.com/package/@quasar/cli?activeTab=versions) is in version 1.3.2 (up to date)
[download-git-repo](https://www.npmjs.com/package/download-git-repo?activeTab=versions) is in version 3.0.2 (up to date)
[download](https://www.npmjs.com/package/download?activeTab=versions) is in version 7.1.0 (most recent 7.x release) ; most recent version does not fix the vulnerability
[got](https://www.npmjs.com/package/got?activeTab=versions) is in version 8.3.1 but patch is in version 11.8.5

The only meaningful thing we can do is upgrade got to version 11.8.5, but I'm afraid the jump from version 8.3.1 might contain breaking change.

```
┌───────────────┬──────────────────────────────────────────────────────────────┐
│ moderate      │ Got allows a redirect to a UNIX socket                       │
├───────────────┼──────────────────────────────────────────────────────────────┤
│ Package       │ got                                                          │
├───────────────┼──────────────────────────────────────────────────────────────┤
│ Patched in    │ >=11.8.5                                                     │
├───────────────┼──────────────────────────────────────────────────────────────┤
│ Dependency of │ @quasar/cli                                                  │
├───────────────┼──────────────────────────────────────────────────────────────┤
│ Path          │ @quasar/cli > update-notifier > latest-version >             │
│               │ package-json > got                                           │
├───────────────┼──────────────────────────────────────────────────────────────┤
│ More info     │ https://www.npmjs.com/advisories/1080920                     │
└───────────────┴──────────────────────────────────────────────────────────────┘
```
[update-notifier](https://www.npmjs.com/package/update-notifier?activeTab=versions) is in version 5.1.0 (most recent 5.x release) ; first version that fixes the vuln is 6.0.1
[latest-version](https://www.npmjs.com/package/latest-version?activeTab=versions) is in version 5.1.0 (most recent 5.x release) ; first version that fixes the vuln is 7.0.0
[package-json](https://www.npmjs.com/package/package-json?activeTab=versions) is in version 6.3.0 ; first version that fixes the vuln is 8.0.0
[got](https://www.npmjs.com/package/got?activeTab=versions) is in version 9.6.0 but patch is in version 11.8.5

Same comment as above. Maybe we can have more luck with the other dependencies.

```
┌───────────────┬──────────────────────────────────────────────────────────────┐
│ high          │ Command injection in git-clone                               │
├───────────────┼──────────────────────────────────────────────────────────────┤
│ Package       │ git-clone                                                    │
├───────────────┼──────────────────────────────────────────────────────────────┤
│ Patched in    │ No patch available                                           │
├───────────────┼──────────────────────────────────────────────────────────────┤
│ Dependency of │ @quasar/cli                                                  │
├───────────────┼──────────────────────────────────────────────────────────────┤
│ Path          │ @quasar/cli > download-git-repo > git-clone                  │
├───────────────┼──────────────────────────────────────────────────────────────┤
│ More info     │ https://www.npmjs.com/advisories/1084214                     │
└───────────────┴──────────────────────────────────────────────────────────────┘
```

There is nothing to do. Good luck with that.