### PR TITLE
Add ECSC task parser

### DIFF
--- a/front/src/ctfnote/parsers/ecsc.ts
+++ b/front/src/ctfnote/parsers/ecsc.ts
@@ -1,0 +1,29 @@
+import { ParsedTask, Parser } from '.';
+import { parseJson, parseJsonStrict } from '../utils';
+
+const ECSCParser: Parser = {
+  name: 'ECSC parser',
+  hint: 'paste ecsc /stats.json',
+
+  parse(s: string): ParsedTask[] {
+    const tasks = [];
+    const data = parseJsonStrict<[{ task: string; contract: string }]>(s);
+    if (!Array.isArray(data)) {
+      return [];
+    }
+
+    for (const task of data) {
+      if (!task.task || !task.contract) {
+        continue;
+      }
+      tasks.push({ title: task.task, category: task.contract });
+    }
+    return tasks;
+  },
+  isValid(s) {
+    const data = parseJson<[{ task: string; contract: string }]>(s);
+    return Array.isArray(data);
+  },
+};
+
+export default ECSCParser;

--- a/front/src/ctfnote/parsers/index.ts
+++ b/front/src/ctfnote/parsers/index.ts
@@ -1,4 +1,5 @@
 import CTFDParser from './ctfd';
+import ECSCParser from './ecsc';
 import RawParser from './raw';
 
 export type ParsedTask = {
@@ -13,4 +14,4 @@ export type Parser = {
   parse(s: string): ParsedTask[];
 };
 
-export default [RawParser, CTFDParser];
+export default [RawParser, CTFDParser, ECSCParser];


### PR DESCRIPTION
With the upcoming [ECSC competition](https://www.ecsc2022.eu/), it is useful to have a special ECSC task parser since some teams will use CTFNote as their note management software, and importing all the tasks yourself is just painful.

This parser parses the JSON output of the `/stats.json` endpoint of the [ECSC gameboard](https://github.com/enisaeu/ecsc-gameboard). The output doesn't contain actual categories, so we use the 'contract' name as the category.

Example JSON output of `/stats.json` to test the parser:
```json
[
    {
        "task": "First task of first contract",
        "contract": "First contract",
        "cash": 0,
        "solved_by": [
            "test"
        ],
        "average_time": "35 seconds"
    },
    {
        "task": "Second task of first contract",
        "contract": "First contract",
        "cash": 0,
        "solved_by": [],
        "average_time": null
    },
    {
        "task": "first task of second contract",
        "contract": "second contract",
        "cash": 10,
        "solved_by": [],
        "average_time": null
    },
    {
        "task": "second task of second contract",
        "contract": "second contract",
        "cash": 10,
        "solved_by": [],
        "average_time": null
    }
]
```