### PR TITLE
Make tasks exportable as Markdown

### DIFF
--- a/front/src/components/Dialogs/TaskExportDialog.vue
+++ b/front/src/components/Dialogs/TaskExportDialog.vue
@@ -100,7 +100,7 @@ export default defineComponent({
 
       // download
       const blob = new Blob([template], {
-        type: 'application/markdown',
+        type: 'text/markdown',
       });
       const link = document.createElement('a');
       link.href = URL.createObjectURL(blob);

--- a/front/src/components/Dialogs/TaskExportDialog.vue
+++ b/front/src/components/Dialogs/TaskExportDialog.vue
@@ -74,7 +74,7 @@ export default defineComponent({
       // Add CTF title
       template += `${this.ctf.title}\n===\n\n`;
       // Add CTF date
-      template += `${this.ctf.startTime.toUTCString()} - ${this.ctf.endTime.toUTCString()}\n`;
+      template += `${this.ctf.startTime.toUTCString()} - ${this.ctf.endTime.toUTCString()}  \n`;
       // Add team name
       if (this.teamName != '') {
         template += `Team: ${this.teamName}\n`;

--- a/front/src/components/Dialogs/TaskExportDialog.vue
+++ b/front/src/components/Dialogs/TaskExportDialog.vue
@@ -71,11 +71,6 @@ export default defineComponent({
     async exportTasks(tasks: Task[]) {
       let template = '';
 
-      // Add logo
-      if (this.ctf.logoUrl != null) {
-        template += `![CTF logo](${this.ctf.logoUrl})\n\n`;
-      }
-
       // Add CTF title
       template += `${this.ctf.title}\n===\n\n`;
       // Add CTF date

--- a/front/src/components/Dialogs/TaskExportDialog.vue
+++ b/front/src/components/Dialogs/TaskExportDialog.vue
@@ -1,0 +1,142 @@
+<template>
+  <q-dialog ref="dialogRef" @hide="onDialogHide">
+    <q-card class="ctfnote-dialog">
+      <q-card-section class="row">
+        <div class="text-h6">Export tasks</div>
+        <q-space />
+        <q-btn v-close-popup icon="close" flat round dense />
+      </q-card-section>
+      <q-card-section>
+        <div>
+          <q-select
+            v-model="currentOption"
+            class="full-width"
+            label="Export Type"
+            :options="exportOptions"
+          />
+          <q-input v-model="teamName" label="Team name" />
+        </div>
+      </q-card-section>
+      <q-card-actions class="q-pr-md q-pb-md" align="right">
+        <q-btn flat color="warning" label="Cancel" @click="backClick" />
+        <q-btn color="positive" label="Export" @click="btnClick" />
+      </q-card-actions>
+    </q-card>
+  </q-dialog>
+</template>
+
+<script lang="ts">
+import { useDialogPluginComponent } from 'quasar';
+import { Ctf, Task } from 'src/ctfnote/models';
+import { defineComponent, ref } from 'vue';
+
+export default defineComponent({
+  props: {
+    ctf: { type: Object as () => Ctf, required: true },
+  },
+  emits: useDialogPluginComponent.emits,
+  setup() {
+    const { dialogRef, onDialogHide, onDialogOK, onDialogCancel } =
+      useDialogPluginComponent();
+
+    const exportOptions = ['Solved tasks only', 'All tasks'];
+
+    return {
+      model: ref(''),
+      currentOption: ref(exportOptions[0]),
+      teamName: ref(''),
+      exportOptions,
+      dialogRef,
+      onDialogHide,
+      onDialogOK,
+      onDialogCancel,
+    };
+  },
+  computed: {},
+  methods: {
+    backClick() {
+      this.onDialogCancel();
+    },
+
+    async downloadTaskMarkdown(task: Task) {
+      const result = await fetch(task.padUrl + '/download/markdown');
+      let markdown = await result.text();
+      if (markdown.trimStart().substring(0, 1) != '#') {
+        //does not start with a title, manually adding...
+        markdown = `# ${task.title} - ${task.category}\n` + markdown;
+      }
+      return markdown;
+    },
+
+    async exportTasks(tasks: Task[]) {
+      let template = '';
+
+      // Add logo
+      if (this.ctf.logoUrl != null) {
+        template += `![CTF logo](${this.ctf.logoUrl})\n\n`;
+      }
+
+      // Add CTF title
+      template += `${this.ctf.title}\n===\n\n`;
+      // Add CTF date
+      template += `${this.ctf.startTime.toUTCString()} - ${this.ctf.endTime.toUTCString()}\n`;
+      // Add team name
+      if (this.teamName != '') {
+        template += `Team: ${this.teamName}\n`;
+      }
+
+      // Add flags table
+      const flagTasks = tasks.filter((f) => f.flag != '');
+      if (flagTasks.length > 0) {
+        template += '\n| Task | Flag |\n|---|---|\n';
+        template += flagTasks
+          .map((flagTask) => `| ${flagTask.title} | ${flagTask.flag} |`)
+          .join('\n');
+      }
+
+      template += '\n\n\n';
+
+      // Add tasks
+      template += (
+        await Promise.all(
+          tasks.flatMap((task) => this.downloadTaskMarkdown(task), this)
+        )
+      ).join('\n\n');
+
+      // download
+      const blob = new Blob([template], {
+        type: 'application/markdown',
+      });
+      const link = document.createElement('a');
+      link.href = URL.createObjectURL(blob);
+      link.download = this.ctf.title + '.md';
+      link.click();
+      URL.revokeObjectURL(link.href);
+    },
+
+    btnClick() {
+      let tasks = this.ctf.tasks;
+      if (this.currentOption == 'Solved tasks only') {
+        tasks = tasks.filter((t) => t.solved);
+      }
+
+      return this.exportTasks(
+        tasks
+          .sort((a, b) =>
+            a.title.toLowerCase().localeCompare(b.title.toLowerCase())
+          )
+          .sort((a, b) =>
+            a.category.toLowerCase().localeCompare(b.category.toLowerCase())
+          )
+      );
+    },
+  },
+});
+</script>
+
+<style scoped>
+.q-dialog-plugin {
+  width: 800px;
+  max-width: 90vw !important;
+}
+</style>

--- a/front/src/components/Task/TaskList.vue
+++ b/front/src/components/Task/TaskList.vue
@@ -90,6 +90,13 @@
           label="Import "
           @click="openImportTaskDialog"
         />
+        <q-fab-action
+          color="accent"
+          push
+          icon="file_download"
+          label="Export "
+          @click="openExportTasksDialog"
+        />
       </q-fab>
     </q-page-sticky>
   </div>
@@ -102,6 +109,7 @@ import { useStoredSettings } from 'src/extensions/storedSettings';
 import { defineComponent, ref, provide } from 'vue';
 import TaskEditDialogVue from '../Dialogs/TaskEditDialog.vue';
 import TaskImportDialogVue from '../Dialogs/TaskImportDialog.vue';
+import TaskExportDialogVue from '../Dialogs/TaskExportDialog.vue';
 import TaskCards from './TaskCards.vue';
 import TaskTable from './TaskTable.vue';
 import { useQuasar } from 'quasar';
@@ -252,6 +260,14 @@ export default defineComponent({
     openImportTaskDialog() {
       this.$q.dialog({
         component: TaskImportDialogVue,
+        componentProps: {
+          ctf: this.ctf,
+        },
+      });
+    },
+    openExportTasksDialog() {
+      this.$q.dialog({
+        component: TaskExportDialogVue,
         componentProps: {
           ctf: this.ctf,
         },


### PR DESCRIPTION
All tasks can now be bundled together to create one big document of tasks that can be submitted as a writeup for a CTF. This saves lots of time copying the tasks in a document one by one.

The user can choose to export all tasks or only the solved tasks.

Optionally, the user can supply a team name to add to the writeup since that is often required if you want to submit it to an organization.

The export is done client side using the APIs of Hedgedoc.

This functionality is especially useful for CTFs where you have to submit your writeup very quickly after the competition (for example the [ECSC](https://ecsc.eu/)).

Example of an export:
```md
![CTF logo](https://ctftime.org/media/events/balsn123.jpg)

Balsn CTF 2022
===

Sat, 03 Sep 2022 02:00:00 GMT - Mon, 05 Sep 2022 02:00:00 GMT
Team: Team name

| Task | Flag |
|---|---|
| First Task | FLAG{TEST} |
| Second Task | FLAG{ASDF} |


# First Task - Category

## Description

Description

----

Some writeup


# Second Task - Category

## Description

Second description

----

Some writeup
```

UI screenshots:

![dialog](https://user-images.githubusercontent.com/34778827/188211669-bdfcdbae-ee7b-4cf7-8972-c61a74a0c22d.png)

![button](https://user-images.githubusercontent.com/34778827/188211727-10ed13a2-d6ae-4ebe-9425-8b8679528825.png)

Feel free to change the layout of the export!