### PR TITLE
Add RCTF Parser basing on CTFD

### DIFF
--- a/front/src/ctfnote/parsers/ctfd.ts
+++ b/front/src/ctfnote/parsers/ctfd.ts
@@ -2,8 +2,8 @@ import { ParsedTask, Parser } from '.';
 import { parseJson, parseJsonStrict } from '../utils';
 
 const CTFDParser: Parser = {
-  name: 'CTFd parser',
-  hint: 'paste ctfd /api/v1/challenges',
+  name: 'CTFd/RCTF parser',
+  hint: 'paste ctfd /api/v1/challenges or rctf /api/v1/challs',
 
   parse(s: string): ParsedTask[] {
     const tasks = [];


### PR DESCRIPTION
The [RCTF platform](https://github.com/redpwn/rctf) uses the same API as [CTFd](https://github.com/CTFd/CTFd), but this is not obvious for the user importing the tasks.
This pull requests adds a parser, that imports the functionality of the CTFdParser but explains api endpoints.