### PR TITLE
Add context menu to task dropdown

### DIFF
--- a/front/src/components/Task/TaskBtnGroup.vue
+++ b/front/src/components/Task/TaskBtnGroup.vue
@@ -38,9 +38,7 @@
 <script lang="ts">
 import ctfnote from 'src/ctfnote';
 import { Task } from 'src/ctfnote/models';
-import { injectStrict } from 'src/ctfnote/utils';
 import { defineComponent } from 'vue';
-import keys from '../../injectionKeys';
 
 export default defineComponent({
   props: {
@@ -55,9 +53,9 @@ export default defineComponent({
       team,
       startWorkingOn: ctfnote.tasks.useStartWorkingOn(),
       stopWorkingOn: ctfnote.tasks.useStopWorkingOn(),
-      solveTask: injectStrict(keys.solveTaskPopup),
-      deleteTask: injectStrict(keys.deleteTaskPopup),
-      editTask: injectStrict(keys.editTaskPopup),
+      solveTask: ctfnote.tasks.useSolveTaskPopup(),
+      deleteTask: ctfnote.tasks.useDeleteTaskPopup(),
+      editTask: ctfnote.tasks.useEditTaskPopup(),
     };
   },
 

--- a/front/src/components/Task/TaskList.vue
+++ b/front/src/components/Task/TaskList.vue
@@ -125,55 +125,9 @@ export default defineComponent({
     ctf: { type: Object as () => Ctf, required: true },
   },
   setup() {
-    const $q = useQuasar();
     const { makePersistant } = useStoredSettings();
 
-    const updateTask = ctfnote.tasks.useUpdateTask();
-    const deleteTask = ctfnote.tasks.useDeleteTask();
     const me = ctfnote.me.injectMe();
-
-    provide(keys.solveTaskPopup, (task: Task) => {
-      $q.dialog({
-        title: 'Flag:',
-        color: 'primary',
-        cancel: {
-          label: 'cancel',
-          color: 'warning',
-          flat: true,
-        },
-        prompt: {
-          model: task.flag ?? '',
-          type: 'text',
-        },
-        ok: {
-          color: 'positive',
-          label: 'save',
-        },
-      }).onOk((flag: string) => {
-        void updateTask(task, { flag });
-      });
-    });
-
-    provide(keys.deleteTaskPopup, (task: Task) => {
-      $q.dialog({
-        title: `Delete ${task.title} ?`,
-        color: 'negative',
-        message: 'This will delete the task, but not the pads.',
-        ok: 'Delete',
-        cancel: true,
-      }).onOk(() => {
-        void deleteTask(task);
-      });
-    });
-
-    provide(keys.editTaskPopup, (task: Task) => {
-      $q.dialog({
-        component: TaskEditDialogVue,
-        componentProps: {
-          task,
-        },
-      });
-    });
 
     const filter = ref('');
     const categoryFilter = ref<string[]>([]);

--- a/front/src/components/Task/TaskList.vue
+++ b/front/src/components/Task/TaskList.vue
@@ -112,7 +112,6 @@ import TaskImportDialogVue from '../Dialogs/TaskImportDialog.vue';
 import TaskExportDialogVue from '../Dialogs/TaskExportDialog.vue';
 import TaskCards from './TaskCards.vue';
 import TaskTable from './TaskTable.vue';
-import { useQuasar } from 'quasar';
 import keys from '../../injectionKeys';
 
 const displayOptions = ['classic', 'dense', 'ultradense', 'table'] as const;

--- a/front/src/components/Task/TaskMenu.vue
+++ b/front/src/components/Task/TaskMenu.vue
@@ -44,8 +44,6 @@
 import { Task } from 'src/ctfnote/models';
 import ctfnote from 'src/ctfnote';
 import { defineComponent } from 'vue';
-import { injectStrict } from 'src/ctfnote/utils';
-import keys from '../../injectionKeys';
 
 export default defineComponent({
   props: {
@@ -56,9 +54,9 @@ export default defineComponent({
       me: ctfnote.me.injectMe(),
       startWorkingOn: ctfnote.tasks.useStartWorkingOn(),
       stopWorkingOn: ctfnote.tasks.useStopWorkingOn(),
-      solveTask: injectStrict(keys.solveTaskPopup),
-      deleteTask: injectStrict(keys.deleteTaskPopup),
-      editTask: injectStrict(keys.editTaskPopup),
+      solveTask: ctfnote.tasks.useSolveTaskPopup(),
+      deleteTask: ctfnote.tasks.useDeleteTaskPopup(),
+      editTask: ctfnote.tasks.useEditTaskPopup(),
     };
   },
   computed: {

--- a/front/src/components/Utils/TaskListMenu.vue
+++ b/front/src/components/Utils/TaskListMenu.vue
@@ -3,6 +3,7 @@
     <q-btn-dropdown stretch flat round>
       <template #label>
         <div class="row q-gutter-md items-center">
+          <task-menu v-if="task" :task="task" />
           <div>{{ title }}</div>
           <div class="col">
             <q-badge v-if="task" :style="colorHash(task.category)">
@@ -20,6 +21,7 @@
             clickable
             :to="taskLink(t)"
           >
+            <task-menu :task="t" />
             <q-item-section>
               <q-item-label>
                 <div class="row" style="max-width: 200px">
@@ -58,9 +60,10 @@
 import { Ctf, Task } from 'src/ctfnote/models';
 import ctfnote from 'src/ctfnote';
 import { defineComponent } from 'vue';
+import TaskMenu from '../Task/TaskMenu.vue';
 
 export default defineComponent({
-  components: {},
+  components: { TaskMenu },
   props: {
     ctf: { type: Object as () => Ctf, required: true },
     taskId: { type: Number, default: null },

--- a/front/src/ctfnote/tasks.ts
+++ b/front/src/ctfnote/tasks.ts
@@ -8,6 +8,8 @@ import {
   useUpdateTaskMutation,
 } from 'src/generated/graphql';
 import { Ctf, Id, Task } from './models';
+import { Dialog } from 'quasar';
+import TaskEditDialogVue from '../components/Dialogs/TaskEditDialog.vue';
 
 /* Mutations */
 export function useCreateTask() {
@@ -35,4 +37,55 @@ export function useStartWorkingOn() {
 export function useStopWorkingOn() {
   const { mutate: doStopWorking } = useStopWorkingOnMutation({});
   return (task: Task) => doStopWorking({ taskId: task.id });
+}
+
+export function useSolveTaskPopup() {
+  const updateTask = useUpdateTask();
+  return (task: Task) => {
+    Dialog.create({
+      title: 'Flag:',
+      color: 'primary',
+      cancel: {
+        label: 'cancel',
+        color: 'warning',
+        flat: true,
+      },
+      prompt: {
+        model: task.flag ?? '',
+        type: 'text',
+      },
+      ok: {
+        color: 'positive',
+        label: 'save',
+      },
+    }).onOk((flag: string) => {
+      void updateTask(task, { flag });
+    });
+  };
+}
+
+export function useDeleteTaskPopup() {
+  const deleteTask = useDeleteTask();
+  return (task: Task) => {
+    Dialog.create({
+      title: `Delete ${task.title}?`,
+      color: 'negative',
+      message: 'This will delete the task, but not the pads.',
+      ok: 'Delete',
+      cancel: true,
+    }).onOk(() => {
+      void deleteTask(task);
+    });
+  };
+}
+
+export function useEditTaskPopup() {
+  return (task: Task) => {
+    Dialog.create({
+      component: TaskEditDialogVue,
+      componentProps: {
+        task,
+      },
+    });
+  };
 }


### PR DESCRIPTION
Now it is possible to edit a task directly from within the Hedgedoc view of a task. This is especially useful when handing in the flag when a task is solved, since you don't have to leave the Hedgedoc view anymore.

The context menu works for both the current task it displays, as well as all the tasks in the dropdown menu.

In order to make this possible, the `solveTaskPopup`, `deleteTaskPopup` and `editTaskPopup` have been moved from a `provide` to a global function that can be imported. This allows the use of these functions within every component instead of only the child components of the TaskList.