### PR TITLE
Fix past CTF table

### DIFF
--- a/front/src/components/CTF/Past.vue
+++ b/front/src/components/CTF/Past.vue
@@ -37,7 +37,13 @@ import { computed, defineComponent, ref, watch } from 'vue';
 import CtfNoteLink from '../Utils/CtfNoteLink.vue';
 import CardAdminMenu from './CardAdminMenu.vue';
 
-type OnRequestProps = { pagination: { rowsPerPage: number; page: number } };
+type OnRequestProps = {
+  pagination: {
+    rowsPerPage: number;
+    page: number;
+    rowsNumber: number;
+  };
+};
 
 export default defineComponent({
   components: { CardAdminMenu, CtfNoteLink },
@@ -56,7 +62,7 @@ export default defineComponent({
     watch(
       () => pastCtfs.value.total,
       (v) => {
-        pagination.value.rowsNumber = v;
+        if (v !== 0) pagination.value.rowsNumber = v;
       },
       { immediate: true }
     );
@@ -71,13 +77,11 @@ export default defineComponent({
           name: 'title',
           classes: 'text-center',
           align: 'center',
-          sortable: true,
           label: 'Title',
         },
         {
           name: 'date',
           align: 'right',
-          sortable: true,
           label: 'Date',
         },
       ],
@@ -88,9 +92,10 @@ export default defineComponent({
       return date.formatDate(ctf.startTime, 'YYYY-MM-DD');
     },
     onRequest(props: OnRequestProps) {
-      const { rowsPerPage, page } = props.pagination;
+      const { rowsPerPage, page, rowsNumber } = props.pagination;
       this.pagination.rowsPerPage = rowsPerPage;
       this.pagination.page = page;
+      this.pagination.rowsNumber = rowsNumber;
     },
   },
 });

--- a/front/src/ctfnote/ctfs.ts
+++ b/front/src/ctfnote/ctfs.ts
@@ -217,6 +217,13 @@ export function getPastCtfs(...args: Parameters<typeof usePastCtfsQuery>) {
       const endTime = extractDate(node.endTime);
       if (endTime < new Date()) {
         nodes.push(node);
+        nodes.sort((a, b) =>
+          Number(new Date(a.startTime)) > Number(new Date(b.startTime))
+            ? -1
+            : Number(new Date(a.startTime)) < Number(new Date(b.startTime))
+            ? 1
+            : 0
+        );
       }
       return {
         pastCtf: {


### PR DESCRIPTION
The next page arrow did not work of the past CTF table but is now fixed. Also this removes the sorting functionality (UI) since it does not work.

If you create a CTF which is in the past, it would appear at the bottom of the past CTF table until you refresh the table.
Now the list is properly sorted which will place the CTF at the expected place.