### PR TITLE
Add ML category to HTB parser

### DIFF
--- a/front/src/ctfnote/parsers/htb.ts
+++ b/front/src/ctfnote/parsers/htb.ts
@@ -23,6 +23,7 @@ const challengeCategories: { [index: number]: string } = {
   18: 'Defence',
   20: 'Cloud',
   21: 'Scada',
+  23: 'ML',
 };
 
 const HTBParser: Parser = {


### PR DESCRIPTION
This was newly added to the challenge categories as listed at https://ctf.hackthebox.com/api/public/challengeCategories