### PR TITLE
Update Hedgedoc to latest version 1.9.7

### DIFF
--- a/docker-compose.dev.yml
+++ b/docker-compose.dev.yml
@@ -15,7 +15,7 @@ services:
     ports:
       - '5432:5432'
   hedgedoc:
-    image: quay.io/hedgedoc/hedgedoc:1.9.4
+    image: quay.io/hedgedoc/hedgedoc:1.9.7
     environment:
       CMD_DB_URL: 'postgres://ctfnote:ctfnote@db:5432/hedgedoc'
       CMD_URL_PATH: 'pad'

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -44,7 +44,7 @@ services:
     ports:
       - 8080:80
   hedgedoc:
-    image: quay.io/hedgedoc/hedgedoc:1.9.4
+    image: quay.io/hedgedoc/hedgedoc:1.9.7
     environment:
       - CMD_DB_URL=postgres://ctfnote:ctfnote@db:5432/hedgedoc
       - CMD_URL_PATH=pad


### PR DESCRIPTION
The release notes of Hedgedoc can be found [here](https://github.com/hedgedoc/hedgedoc/releases).