### PR TITLE
Update Hedgedoc to 1.9.8

### DIFF
--- a/docker-compose.dev.yml
+++ b/docker-compose.dev.yml
@@ -13,14 +13,14 @@ services:
     networks:
       - ctfnote
     ports:
-      - '5432:5432'
+      - "5432:5432"
   hedgedoc:
-    image: quay.io/hedgedoc/hedgedoc:1.9.7
+    image: quay.io/hedgedoc/hedgedoc:1.9.8
     environment:
-      CMD_DB_URL: 'postgres://ctfnote:ctfnote@db:5432/hedgedoc'
-      CMD_URL_PATH: 'pad'
-      CMD_IMAGE_UPLOAD_TYPE: 'filesystem'
-      CMD_CSP_ENABLE: 'false'
+      CMD_DB_URL: "postgres://ctfnote:ctfnote@db:5432/hedgedoc"
+      CMD_URL_PATH: "pad"
+      CMD_IMAGE_UPLOAD_TYPE: "filesystem"
+      CMD_CSP_ENABLE: "false"
     depends_on:
       - db
     restart: always
@@ -29,7 +29,7 @@ services:
     networks:
       - ctfnote
     ports:
-      - '3001:3000'
+      - "3001:3000"
 volumes:
   ctfnote-db:
   pad-uploads:

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -44,7 +44,7 @@ services:
     ports:
       - 8080:80
   hedgedoc:
-    image: quay.io/hedgedoc/hedgedoc:1.9.7
+    image: quay.io/hedgedoc/hedgedoc:1.9.8
     environment:
       - CMD_DB_URL=postgres://ctfnote:ctfnote@db:5432/hedgedoc
       - CMD_URL_PATH=pad


### PR DESCRIPTION
Release notes can be found here: https://github.com/hedgedoc/hedgedoc/releases/tag/1.9.8

Prettier also urgently wanted to replace all `'` with `"` to be consistent :) 