### PR TITLE
Add ångstromCTF parser

### DIFF
--- a/front/src/ctfnote/parsers/angstrom.ts
+++ b/front/src/ctfnote/parsers/angstrom.ts
@@ -1,0 +1,44 @@
+import { ParsedTask, Parser } from '.';
+import { parseJson, parseJsonStrict } from '../utils';
+
+const AngstromParser: Parser = {
+  name: 'ångstromCTF parser',
+  hint: 'paste api.angstromctf.com/competitions/XX/challenges with XX being the event id',
+
+  parse(s: string): ParsedTask[] {
+    const tasks = [];
+    const data =
+      parseJsonStrict<
+        Array<{ title: string; category: string; description: string }>
+      >(s);
+    if (!Array.isArray(data)) {
+      return [];
+    }
+    for (const task of data) {
+      if (!task.title || !task.category) {
+        continue;
+      }
+      tasks.push({
+        title: task.title,
+        category: task.category,
+        description: task.description,
+      });
+    }
+    return tasks;
+  },
+  isValid(s) {
+    const data =
+      parseJson<
+        Array<{ title: string; category: string; description: string }>
+      >(s);
+    return (
+      Array.isArray(data) &&
+      data.length > 0 &&
+      data[0].title != null &&
+      data[0].category != null &&
+      data[0].description != null
+    );
+  },
+};
+
+export default AngstromParser;

--- a/front/src/ctfnote/parsers/index.ts
+++ b/front/src/ctfnote/parsers/index.ts
@@ -4,6 +4,7 @@ import RawParser from './raw';
 import HTBParser from './htb';
 import PicoParser from './pico';
 import justCTFParser from './justctf';
+import AngstromParser from './angstrom';
 
 export type ParsedTask = {
   title: string;
@@ -26,4 +27,5 @@ export default [
   HTBParser,
   PicoParser,
   justCTFParser,
+  AngstromParser,
 ];


### PR DESCRIPTION
Allows to add ångstromCTF challenges from https://angstromctf.com/

I've mimiced the stricter `isValid` tests from the justCTF parser addition PR, but didn't test it afterwards. During the CTF I only had the `isArray` check, but since their platform has problems currently, I can't test it with the stricter checks. But given the pico and justCTF parsers are similar, I'd expect this to still be fine.