### PR TITLE
Fix .env copy instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,7 +10,7 @@ CTFNote is a collaborative tool aiming to help CTF teams to organise their work.
 
 ## Installation
 
-Before starting, make sure to fill copy `.env.example` to `.env` and fill in the information in the `.env` file.
+**Before starting**, make sure to copy `.env.example` to `.env` and fill in the information in the `.env` file.
 
 ### Running the Docker containers
 


### PR DESCRIPTION
There was a typo and now we make the first two words bold so people won't skip it hopefully.