### PR TITLE
Improve iCal endpoint

### DIFF
--- a/api/src/routes/ical.ts
+++ b/api/src/routes/ical.ts
@@ -53,6 +53,7 @@ export function icalRoute(pool: Pool): Handler {
 
     for (const ctf of ctfs) {
       cal.createEvent({
+        id: ctf.id,
         start: ctf.start_time,
         end: ctf.end_time,
         description: ctf.description,

--- a/api/src/routes/ical.ts
+++ b/api/src/routes/ical.ts
@@ -54,8 +54,9 @@ export function icalRoute(pool: Pool): Handler {
     const ctfs = await getCtfs();
 
     for (const ctf of ctfs) {
+      const ctftime_id = ctf.ctftime_url?.replace(/\/$/, "").split("/").at(-1);
       cal.createEvent({
-        id: `${ctf.id}@${config.pad.domain}`,
+        id: `${ctf.id}:${ctftime_id || "no-ctftime"}@${config.pad.domain ||  "ctfnote"}`,
         start: ctf.start_time,
         end: ctf.end_time,
         description: ctf.description,

--- a/api/src/routes/ical.ts
+++ b/api/src/routes/ical.ts
@@ -1,6 +1,7 @@
 import { ICalCalendar } from "ical-generator";
 import { Request, Response, Handler } from "express";
 import { Pool } from "pg";
+import config from "../config";
 
 type CtfRow = {
   id: number;
@@ -54,7 +55,7 @@ export function icalRoute(pool: Pool): Handler {
 
     for (const ctf of ctfs) {
       cal.createEvent({
-        id: ctf.id,
+        id: `${ctf.id}@${config.pad.domain}`,
         start: ctf.start_time,
         end: ctf.end_time,
         description: ctf.description,

--- a/api/src/routes/ical.ts
+++ b/api/src/routes/ical.ts
@@ -8,6 +8,7 @@ type CtfRow = {
   start_time: string;
   end_time: string;
   ctf_url: string;
+  ctftime_url: string;
   description: string;
 };
 
@@ -30,7 +31,7 @@ export function icalRoute(pool: Pool): Handler {
 
   async function getCtfs(): Promise<CtfRow[]> {
     const r = await pool.query<CtfRow>(
-      "SELECT id, title, start_time, end_time, ctf_url, description FROM ctfnote.ctf"
+      "SELECT id, title, start_time, end_time, ctf_url, ctftime_url, description FROM ctfnote.ctf"
     );
 
     return r.rows;
@@ -59,6 +60,7 @@ export function icalRoute(pool: Pool): Handler {
         description: ctf.description,
         summary: ctf.title,
         url: ctf.ctf_url,
+        attachments: [ctf.ctftime_url],
       });
     }
 

--- a/api/src/routes/ical.ts
+++ b/api/src/routes/ical.ts
@@ -62,7 +62,7 @@ export function icalRoute(pool: Pool): Handler {
         description: ctf.description,
         summary: ctf.title,
         url: ctf.ctf_url,
-        attachments: [ctf.ctftime_url],
+        attachments: ctf.ctftime_url ? [ctf.ctftime_url] : [],
       });
     }
 

--- a/api/src/routes/ical.ts
+++ b/api/src/routes/ical.ts
@@ -56,7 +56,7 @@ export function icalRoute(pool: Pool): Handler {
     for (const ctf of ctfs) {
       const ctftime_id = ctf.ctftime_url?.replace(/\/$/, "").split("/").at(-1);
       cal.createEvent({
-        id: `${ctf.id}:${ctftime_id || "no-ctftime"}@${config.pad.domain ||  "ctfnote"}`,
+        id: `${ctf.id}:${ctftime_id || "no-ctftime"}@${config.pad.domain || "ctfnote"}`,
         start: ctf.start_time,
         end: ctf.end_time,
         description: ctf.description,


### PR DESCRIPTION
This PR adds two features to the iCal endpoint:
- use ctf id and pad domain as persistent UID
  - currently a UUID is generated for each request
  - the [spec](https://www.rfc-editor.org/rfc/rfc5545#section-3.8.4.7) requires the UID to be persistent
- add ctftime_url as ATTACH
  - this allows to retrieve more information about the ctf from ctftime