### PR TITLE
Fix custom shortcuts in HedgeDoc editor not always working

### DIFF
--- a/front/public/hotkeys-iframe.js
+++ b/front/public/hotkeys-iframe.js
@@ -359,6 +359,12 @@
 // above is the hotkeys.js library code
 // CTFNote code starts here:
 
+// Disable hotkeys.js INPUT, SELECT and TEXTAREA filter (https://wangchujiang.com/hotkeys-js/#filter)
+// This is required for shortcuts to work in HedgeDoc's CodeMirror editor
+hotkeys.filter = function() {
+  return true;
+}
+
 hotkeys('ctrl+k, command+k', function (event) {
   event.stopImmediatePropagation();
   event.preventDefault();
@@ -371,24 +377,4 @@ hotkeys('ctrl+s, command+s', function (event) {
   event.preventDefault();
 
   parent.postMessage('solveTask', '*');
-});
-
-// Hotkeys for HedgeDoc CodeMirror editor
-editor.setOption('extraKeys', {
-  'Ctrl-K': () => {
-    parent.postMessage('showSearchDialog', '*');
-    return false;
-  },
-  'Cmd-K': () => {
-    parent.postMessage('showSearchDialog', '*');
-    return false;
-  },
-  'Ctrl-S': () => {
-    parent.postMessage('solveTask', '*');
-    return false;
-  },
-  'Cmd-S': () => {
-    parent.postMessage('solveTask', '*');
-    return false;
-  },
 });


### PR DESCRIPTION
Instead of adding the shortcuts to HedgeDoc's CodeMirror editor directly by setting `extraKeys`, I disabled the filter on different input elements that `hotkeys.js` uses by default. (See https://wangchujiang.com/hotkeys-js/#filter). This allows the shortcuts defined by `hotkeys.js` to work in the editor as well.

Setting `extraKeys` also overrides the default shortcuts that CodeMirror defines, such as <kbd>f10</kbd> to make the editor take up the full window. Since this code does not override this anymore, these shortcuts should work again after this change.

There should be no or little overlap with default CodeMirror hotkeys, but it is still a good idea to test if nothing breaks because of this change.

Closes #450