### PR TITLE
Fix 50 plus category creation discord bot

### DIFF
--- a/api/src/discord/agile/hooks.ts
+++ b/api/src/discord/agile/hooks.ts
@@ -198,7 +198,7 @@ const discordMutationHook = (_build: Build) => (fieldContext: Context<any>) => {
     //add challenges to the ctf channel discord
     switch (fieldContext.scope.fieldName) {
       case "createTask":
-        handleCreateTask(
+        await handleCreateTask(
           guild,
           args.input.ctfId,
           args.input.title,


### PR DESCRIPTION
Since we do not support batch importing tasks, the frontend spams the backend with a lot of task creations.
Due to throttling from Discord, it fails to create the extra Discord category for 50+ challenges.
This will break the channel creation.

So the fix for this without supporting batch import, is to import with batches from 10 where each first task is done in serial and the other 9 in parallel.